### PR TITLE
feat: 운동 데이터 상세보기 & 전체목록 UI 구현 (#8)

### DIFF
--- a/lib/features/workout/presentation/pages/dashboard_page.dart
+++ b/lib/features/workout/presentation/pages/dashboard_page.dart
@@ -6,6 +6,8 @@ import 'package:co_workfit/features/workout/presentation/bloc/workout_event.dart
 import 'package:co_workfit/features/workout/presentation/bloc/workout_state.dart';
 import 'package:co_workfit/features/workout/presentation/widgets/workout_list_item.dart';
 import 'package:co_workfit/features/workout/presentation/pages/health_debug_page.dart';
+import 'package:co_workfit/features/workout/presentation/pages/workout_list_page.dart';
+import 'package:co_workfit/features/workout/presentation/pages/workout_detail_page.dart';
 import 'package:co_workfit/core/di/injection.dart' as di;
 import 'package:co_workfit/features/workout/domain/repositories/workout_repository.dart';
 
@@ -407,9 +409,11 @@ class _DashboardPageState extends State<DashboardPage> {
             if (state is WorkoutLoaded && state.workouts.isNotEmpty)
               TextButton.icon(
                 onPressed: () {
-                  // TODO: 전체 운동 목록 페이지로 이동
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('전체 운동 목록 페이지 준비 중')),
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const WorkoutListPage(),
+                    ),
                   );
                 },
                 icon: const Icon(Icons.list),
@@ -460,7 +464,17 @@ class _DashboardPageState extends State<DashboardPage> {
           Column(
             children: state.workouts
                 .take(5) // 최근 5개만 표시
-                .map((workout) => WorkoutListItem(workout: workout))
+                .map((workout) => WorkoutListItem(
+                      workout: workout,
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => WorkoutDetailPage(workout: workout),
+                          ),
+                        );
+                      },
+                    ))
                 .toList(),
           )
         else if (state is WorkoutPermissionDenied)

--- a/lib/features/workout/presentation/pages/workout_detail_page.dart
+++ b/lib/features/workout/presentation/pages/workout_detail_page.dart
@@ -1,0 +1,553 @@
+import 'package:flutter/material.dart';
+import 'package:co_workfit/features/workout/domain/entities/workout_entity.dart';
+import 'package:intl/intl.dart';
+
+/// 운동 상세보기 페이지
+class WorkoutDetailPage extends StatelessWidget {
+  final WorkoutEntity workout;
+
+  const WorkoutDetailPage({
+    super.key,
+    required this.workout,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('운동 상세'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.share),
+            onPressed: () {
+              // TODO: 공유 기능 (향후 소셜 기능 연동)
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('공유 기능 준비 중')),
+              );
+            },
+            tooltip: '공유',
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            // 상단 헤더 (운동 타입 및 아이콘)
+            _buildHeader(context),
+
+            // 점수 카드 (강조)
+            _buildScoreCard(context),
+
+            // 운동 상세 정보
+            _buildWorkoutInfo(context),
+
+            // 캘리브레이션 정보
+            _buildCalibrationInfo(context),
+
+            // 데이터 소스
+            _buildSourceInfo(context),
+
+            const SizedBox(height: 24),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: _getWorkoutColor(workout.type).withValues(alpha: 0.1),
+      ),
+      child: Column(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: _getWorkoutColor(workout.type),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              _getWorkoutIcon(workout.type),
+              size: 48,
+              color: Colors.white,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            _getWorkoutTypeName(workout.type),
+            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            _formatDateTime(workout.startTime),
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: Colors.grey[700],
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScoreCard(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.all(16),
+      elevation: 4,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Theme.of(context).colorScheme.primary,
+              Theme.of(context).colorScheme.primary.withValues(alpha: 0.7),
+            ],
+          ),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          children: [
+            Text(
+              '획득 점수',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Colors.white,
+                  ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                const Icon(
+                  Icons.star,
+                  size: 40,
+                  color: Colors.amber,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '${workout.calibratedScore}',
+                  style: Theme.of(context).textTheme.displayLarge?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+                const SizedBox(width: 4),
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Text(
+                    '점',
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          color: Colors.white70,
+                        ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '운동 강도: ${workout.calibratedWorkload.toStringAsFixed(1)}',
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: Colors.white70,
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWorkoutInfo(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.info_outline,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '운동 정보',
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            _buildInfoRow(
+              context,
+              Icons.access_time,
+              '시작 시간',
+              DateFormat('yyyy년 MM월 dd일 HH:mm').format(workout.startTime),
+            ),
+            const Divider(height: 24),
+            _buildInfoRow(
+              context,
+              Icons.timer,
+              '종료 시간',
+              DateFormat('yyyy년 MM월 dd일 HH:mm').format(workout.endTime),
+            ),
+            const Divider(height: 24),
+            _buildInfoRow(
+              context,
+              Icons.timelapse,
+              '총 시간',
+              '${workout.durationMinutes}분',
+            ),
+            if (workout.calories != null) ...[
+              const Divider(height: 24),
+              _buildInfoRow(
+                context,
+                Icons.local_fire_department,
+                '칼로리',
+                '${workout.calories} kcal',
+              ),
+            ],
+            if (workout.distance != null) ...[
+              const Divider(height: 24),
+              _buildInfoRow(
+                context,
+                Icons.straighten,
+                '거리',
+                '${workout.distance!.toStringAsFixed(2)} km',
+              ),
+            ],
+            if (workout.averageHeartRate != null) ...[
+              const Divider(height: 24),
+              _buildInfoRow(
+                context,
+                Icons.favorite,
+                '평균 심박수',
+                '${workout.averageHeartRate} BPM',
+              ),
+            ],
+            if (workout.maxHeartRate != null) ...[
+              const Divider(height: 24),
+              _buildInfoRow(
+                context,
+                Icons.favorite_border,
+                '최대 심박수',
+                '${workout.maxHeartRate} BPM',
+              ),
+            ],
+            if (workout.steps != null) ...[
+              const Divider(height: 24),
+              _buildInfoRow(
+                context,
+                Icons.directions_walk,
+                '걸음 수',
+                '${workout.steps} 걸음',
+              ),
+            ],
+            if (workout.elevationGain != null) ...[
+              const Divider(height: 24),
+              _buildInfoRow(
+                context,
+                Icons.terrain,
+                '고도 상승',
+                '${workout.elevationGain!.toStringAsFixed(1)} m',
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCalibrationInfo(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.analytics_outlined,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '캘리브레이션 정보',
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            _buildInfoRow(
+              context,
+              Icons.fitness_center,
+              '표준화된 운동 강도',
+              workout.calibratedWorkload.toStringAsFixed(2),
+            ),
+            const Divider(height: 24),
+            _buildInfoRow(
+              context,
+              Icons.star_rate,
+              '난이도',
+              _getDifficultyLevel(workout.calibratedWorkload),
+            ),
+            const Divider(height: 24),
+            _buildInfoRow(
+              context,
+              Icons.smartphone,
+              '플랫폼 보정',
+              _getSourceCorrectionInfo(workout.source),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSourceInfo(BuildContext context) {
+    final sourceInfo = _getSourceInfo(workout.source);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.source_outlined,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '데이터 소스',
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.grey[200],
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Icon(
+                    sourceInfo['icon'] as IconData,
+                    size: 32,
+                    color: Colors.grey[700],
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        sourceInfo['name'] as String,
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        sourceInfo['description'] as String,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              color: Colors.grey[600],
+                            ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            if (workout.syncedAt != null) ...[
+              const SizedBox(height: 12),
+              Text(
+                '동기화: ${DateFormat('yyyy-MM-dd HH:mm').format(workout.syncedAt!)}',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Colors.grey[600],
+                    ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(
+    BuildContext context,
+    IconData icon,
+    String label,
+    String value,
+  ) {
+    return Row(
+      children: [
+        Icon(icon, size: 24, color: Colors.grey[600]),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: Colors.grey[700],
+                ),
+          ),
+        ),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+      ],
+    );
+  }
+
+  IconData _getWorkoutIcon(WorkoutType type) {
+    switch (type) {
+      case WorkoutType.running:
+        return Icons.directions_run;
+      case WorkoutType.cycling:
+        return Icons.directions_bike;
+      case WorkoutType.walking:
+        return Icons.directions_walk;
+      case WorkoutType.swimming:
+        return Icons.pool;
+      case WorkoutType.weightTraining:
+        return Icons.fitness_center;
+      case WorkoutType.yoga:
+        return Icons.self_improvement;
+      case WorkoutType.hiking:
+        return Icons.terrain;
+      case WorkoutType.other:
+        return Icons.sports;
+    }
+  }
+
+  Color _getWorkoutColor(WorkoutType type) {
+    switch (type) {
+      case WorkoutType.running:
+        return Colors.orange;
+      case WorkoutType.cycling:
+        return Colors.blue;
+      case WorkoutType.walking:
+        return Colors.green;
+      case WorkoutType.swimming:
+        return Colors.cyan;
+      case WorkoutType.weightTraining:
+        return Colors.red;
+      case WorkoutType.yoga:
+        return Colors.purple;
+      case WorkoutType.hiking:
+        return Colors.brown;
+      case WorkoutType.other:
+        return Colors.grey;
+    }
+  }
+
+  String _getWorkoutTypeName(WorkoutType type) {
+    switch (type) {
+      case WorkoutType.running:
+        return '러닝';
+      case WorkoutType.cycling:
+        return '사이클링';
+      case WorkoutType.walking:
+        return '걷기';
+      case WorkoutType.swimming:
+        return '수영';
+      case WorkoutType.weightTraining:
+        return '웨이트 트레이닝';
+      case WorkoutType.yoga:
+        return '요가';
+      case WorkoutType.hiking:
+        return '등산';
+      case WorkoutType.other:
+        return '기타 운동';
+    }
+  }
+
+  Map<String, dynamic> _getSourceInfo(WorkoutSource source) {
+    switch (source) {
+      case WorkoutSource.appleHealth:
+        return {
+          'name': 'Apple Health',
+          'icon': Icons.apple,
+          'description': 'Apple HealthKit에서 가져온 데이터',
+        };
+      case WorkoutSource.googleFit:
+        return {
+          'name': 'Google Fit',
+          'icon': Icons.android,
+          'description': 'Google Fit에서 가져온 데이터',
+        };
+      case WorkoutSource.garmin:
+        return {
+          'name': 'Garmin',
+          'icon': Icons.watch,
+          'description': 'Garmin Connect에서 가져온 데이터',
+        };
+      case WorkoutSource.samsungHealth:
+        return {
+          'name': 'Samsung Health',
+          'icon': Icons.smartphone,
+          'description': 'Samsung Health에서 가져온 데이터',
+        };
+      case WorkoutSource.manual:
+        return {
+          'name': '수동 입력',
+          'icon': Icons.edit,
+          'description': '사용자가 직접 입력한 데이터',
+        };
+    }
+  }
+
+  String _getDifficultyLevel(double workload) {
+    if (workload >= 80) {
+      return '매우 높음 🔥🔥🔥';
+    } else if (workload >= 60) {
+      return '높음 🔥🔥';
+    } else if (workload >= 40) {
+      return '보통 🔥';
+    } else if (workload >= 20) {
+      return '낮음 ⭐';
+    } else {
+      return '매우 낮음 ⚡';
+    }
+  }
+
+  String _getSourceCorrectionInfo(WorkoutSource source) {
+    switch (source) {
+      case WorkoutSource.appleHealth:
+        return '높은 정확도 (기준)';
+      case WorkoutSource.googleFit:
+        return '플랫폼 보정 적용됨';
+      case WorkoutSource.garmin:
+        return '높은 정확도';
+      case WorkoutSource.samsungHealth:
+        return '플랫폼 보정 적용됨';
+      case WorkoutSource.manual:
+        return '수동 입력 (보정 없음)';
+    }
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    return DateFormat('yyyy년 MM월 dd일 HH:mm').format(dateTime);
+  }
+}

--- a/lib/features/workout/presentation/pages/workout_list_page.dart
+++ b/lib/features/workout/presentation/pages/workout_list_page.dart
@@ -25,6 +25,7 @@ class _WorkoutListPageState extends State<WorkoutListPage> {
   final ScrollController _scrollController = ScrollController();
   int _loadedDays = 30;
   bool _isLoadingMore = false;
+  List<WorkoutEntity> _allWorkouts = []; // 로컬에서 관리하는 전체 데이터
 
   @override
   void initState() {
@@ -55,21 +56,16 @@ class _WorkoutListPageState extends State<WorkoutListPage> {
   }
 
   void _loadMoreData() {
+    if (_isLoadingMore) return;
+
     setState(() {
       _isLoadingMore = true;
-      _loadedDays += 30; // 30일씩 더 로드
     });
 
-    context.read<WorkoutBloc>().add(FetchRecentWorkoutsEvent(days: _loadedDays));
+    final newDays = _loadedDays + 30;
 
-    // 로딩 완료 후 플래그 해제
-    Future.delayed(const Duration(milliseconds: 500), () {
-      if (mounted) {
-        setState(() {
-          _isLoadingMore = false;
-        });
-      }
-    });
+    // 새로운 범위의 데이터 요청
+    context.read<WorkoutBloc>().add(FetchRecentWorkoutsEvent(days: newDays));
   }
 
   @override
@@ -136,13 +132,29 @@ class _WorkoutListPageState extends State<WorkoutListPage> {
           ),
         ],
       ),
-      body: BlocBuilder<WorkoutBloc, WorkoutState>(
+      body: BlocConsumer<WorkoutBloc, WorkoutState>(
+        listener: (context, state) {
+          if (state is WorkoutLoaded) {
+            setState(() {
+              _allWorkouts = state.workouts;
+              _loadedDays = (_allWorkouts.isNotEmpty)
+                  ? DateTime.now().difference(_allWorkouts.last.startTime).inDays + 1
+                  : 30;
+              _isLoadingMore = false;
+            });
+          } else if (state is WorkoutError) {
+            setState(() {
+              _isLoadingMore = false;
+            });
+          }
+        },
         builder: (context, state) {
-          if (state is WorkoutLoading) {
+          // 초기 로딩 중일 때만 로딩 인디케이터 표시 (데이터가 없을 때)
+          if (state is WorkoutLoading && _allWorkouts.isEmpty) {
             return const Center(child: CircularProgressIndicator());
           }
 
-          if (state is WorkoutError) {
+          if (state is WorkoutError && _allWorkouts.isEmpty) {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -174,7 +186,7 @@ class _WorkoutListPageState extends State<WorkoutListPage> {
             );
           }
 
-          if (state is WorkoutEmpty) {
+          if (state is WorkoutEmpty && _allWorkouts.isEmpty) {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
@@ -203,8 +215,9 @@ class _WorkoutListPageState extends State<WorkoutListPage> {
             );
           }
 
-          if (state is WorkoutLoaded) {
-            var workouts = state.workouts;
+          // 로컬 데이터 사용
+          if (_allWorkouts.isNotEmpty) {
+            var workouts = _allWorkouts;
 
             // 필터 적용
             if (_selectedType != null) {
@@ -271,9 +284,10 @@ class _WorkoutListPageState extends State<WorkoutListPage> {
               onRefresh: () async {
                 setState(() {
                   _loadedDays = 30;
+                  _allWorkouts = [];
                 });
                 context.read<WorkoutBloc>().add(
-                      const RefreshWorkoutsEvent(),
+                      const FetchRecentWorkoutsEvent(days: 30),
                     );
                 await Future.delayed(const Duration(seconds: 1));
               },

--- a/lib/features/workout/presentation/pages/workout_list_page.dart
+++ b/lib/features/workout/presentation/pages/workout_list_page.dart
@@ -22,12 +22,53 @@ class _WorkoutListPageState extends State<WorkoutListPage> {
   WorkoutSource? _selectedSource;
   String _sortBy = 'latest'; // 'latest', 'oldest', 'score_high', 'score_low'
 
+  final ScrollController _scrollController = ScrollController();
+  int _loadedDays = 30;
+  bool _isLoadingMore = false;
+
   @override
   void initState() {
     super.initState();
     // 최근 30일 데이터 로드
     WidgetsBinding.instance.addPostFrameCallback((_) {
       context.read<WorkoutBloc>().add(const FetchRecentWorkoutsEvent(days: 30));
+    });
+
+    // 스크롤 리스너 추가
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_isLoadingMore) return;
+
+    // 스크롤이 끝에서 200px 이내에 도달하면 더 로드
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 200) {
+      _loadMoreData();
+    }
+  }
+
+  void _loadMoreData() {
+    setState(() {
+      _isLoadingMore = true;
+      _loadedDays += 30; // 30일씩 더 로드
+    });
+
+    context.read<WorkoutBloc>().add(FetchRecentWorkoutsEvent(days: _loadedDays));
+
+    // 로딩 완료 후 플래그 해제
+    Future.delayed(const Duration(milliseconds: 500), () {
+      if (mounted) {
+        setState(() {
+          _isLoadingMore = false;
+        });
+      }
     });
   }
 
@@ -228,15 +269,31 @@ class _WorkoutListPageState extends State<WorkoutListPage> {
 
             return RefreshIndicator(
               onRefresh: () async {
+                setState(() {
+                  _loadedDays = 30;
+                });
                 context.read<WorkoutBloc>().add(
                       const RefreshWorkoutsEvent(),
                     );
                 await Future.delayed(const Duration(seconds: 1));
               },
               child: ListView.builder(
+                controller: _scrollController,
                 padding: const EdgeInsets.symmetric(vertical: 8),
-                itemCount: groupedWorkouts.length,
+                itemCount: groupedWorkouts.length + 1, // +1 for loading indicator
                 itemBuilder: (context, index) {
+                  // 마지막 아이템은 로딩 인디케이터
+                  if (index == groupedWorkouts.length) {
+                    return _isLoadingMore
+                        ? const Padding(
+                            padding: EdgeInsets.all(16),
+                            child: Center(
+                              child: CircularProgressIndicator(),
+                            ),
+                          )
+                        : const SizedBox(height: 16);
+                  }
+
                   final entry = groupedWorkouts[index];
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/workout/presentation/pages/workout_list_page.dart
+++ b/lib/features/workout/presentation/pages/workout_list_page.dart
@@ -1,0 +1,340 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:co_workfit/features/workout/presentation/bloc/workout_bloc.dart';
+import 'package:co_workfit/features/workout/presentation/bloc/workout_event.dart';
+import 'package:co_workfit/features/workout/presentation/bloc/workout_state.dart';
+import 'package:co_workfit/features/workout/presentation/widgets/workout_list_item.dart';
+import 'package:co_workfit/features/workout/presentation/pages/workout_detail_page.dart';
+import 'package:co_workfit/features/workout/presentation/widgets/filter_bottom_sheet.dart';
+import 'package:co_workfit/features/workout/domain/entities/workout_entity.dart';
+import 'package:intl/intl.dart';
+
+/// 운동 전체목록 페이지
+class WorkoutListPage extends StatefulWidget {
+  const WorkoutListPage({super.key});
+
+  @override
+  State<WorkoutListPage> createState() => _WorkoutListPageState();
+}
+
+class _WorkoutListPageState extends State<WorkoutListPage> {
+  WorkoutType? _selectedType;
+  WorkoutSource? _selectedSource;
+  String _sortBy = 'latest'; // 'latest', 'oldest', 'score_high', 'score_low'
+
+  @override
+  void initState() {
+    super.initState();
+    // 최근 30일 데이터 로드
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<WorkoutBloc>().add(const FetchRecentWorkoutsEvent(days: 30));
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('전체 운동 기록'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.filter_list),
+            onPressed: _showFilterSheet,
+            tooltip: '필터',
+          ),
+          PopupMenuButton<String>(
+            icon: const Icon(Icons.sort),
+            tooltip: '정렬',
+            onSelected: (value) {
+              setState(() {
+                _sortBy = value;
+              });
+            },
+            itemBuilder: (context) => [
+              PopupMenuItem(
+                value: 'latest',
+                child: Row(
+                  children: [
+                    if (_sortBy == 'latest') const Icon(Icons.check, size: 20),
+                    if (_sortBy == 'latest') const SizedBox(width: 8),
+                    const Text('최신순'),
+                  ],
+                ),
+              ),
+              PopupMenuItem(
+                value: 'oldest',
+                child: Row(
+                  children: [
+                    if (_sortBy == 'oldest') const Icon(Icons.check, size: 20),
+                    if (_sortBy == 'oldest') const SizedBox(width: 8),
+                    const Text('오래된순'),
+                  ],
+                ),
+              ),
+              PopupMenuItem(
+                value: 'score_high',
+                child: Row(
+                  children: [
+                    if (_sortBy == 'score_high') const Icon(Icons.check, size: 20),
+                    if (_sortBy == 'score_high') const SizedBox(width: 8),
+                    const Text('점수 높은순'),
+                  ],
+                ),
+              ),
+              PopupMenuItem(
+                value: 'score_low',
+                child: Row(
+                  children: [
+                    if (_sortBy == 'score_low') const Icon(Icons.check, size: 20),
+                    if (_sortBy == 'score_low') const SizedBox(width: 8),
+                    const Text('점수 낮은순'),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: BlocBuilder<WorkoutBloc, WorkoutState>(
+        builder: (context, state) {
+          if (state is WorkoutLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state is WorkoutError) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.error_outline, size: 64, color: Colors.red[300]),
+                  const SizedBox(height: 16),
+                  Text(
+                    '데이터를 불러올 수 없습니다',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    state.message,
+                    style: Theme.of(context).textTheme.bodySmall,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton.icon(
+                    onPressed: () {
+                      context.read<WorkoutBloc>().add(
+                            const FetchRecentWorkoutsEvent(days: 30),
+                          );
+                    },
+                    icon: const Icon(Icons.refresh),
+                    label: const Text('다시 시도'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          if (state is WorkoutEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.fitness_center,
+                    size: 80,
+                    color: Colors.grey[400],
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    '운동 기록이 없습니다',
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          color: Colors.grey[600],
+                        ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '첫 운동을 시작해보세요!',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                          color: Colors.grey[500],
+                        ),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          if (state is WorkoutLoaded) {
+            var workouts = state.workouts;
+
+            // 필터 적용
+            if (_selectedType != null) {
+              workouts = workouts
+                  .where((w) => w.type == _selectedType)
+                  .toList();
+            }
+            if (_selectedSource != null) {
+              workouts = workouts
+                  .where((w) => w.source == _selectedSource)
+                  .toList();
+            }
+
+            // 정렬
+            workouts = List.from(workouts);
+            switch (_sortBy) {
+              case 'latest':
+                workouts.sort((a, b) => b.startTime.compareTo(a.startTime));
+                break;
+              case 'oldest':
+                workouts.sort((a, b) => a.startTime.compareTo(b.startTime));
+                break;
+              case 'score_high':
+                workouts.sort((a, b) => b.calibratedScore.compareTo(a.calibratedScore));
+                break;
+              case 'score_low':
+                workouts.sort((a, b) => a.calibratedScore.compareTo(b.calibratedScore));
+                break;
+            }
+
+            if (workouts.isEmpty) {
+              return Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.filter_alt_off, size: 64, color: Colors.grey[400]),
+                    const SizedBox(height: 16),
+                    Text(
+                      '필터 조건에 맞는 운동이 없습니다',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            color: Colors.grey[600],
+                          ),
+                    ),
+                    const SizedBox(height: 24),
+                    ElevatedButton.icon(
+                      onPressed: () {
+                        setState(() {
+                          _selectedType = null;
+                          _selectedSource = null;
+                        });
+                      },
+                      icon: const Icon(Icons.clear),
+                      label: const Text('필터 초기화'),
+                    ),
+                  ],
+                ),
+              );
+            }
+
+            // 날짜별 그룹핑
+            final groupedWorkouts = _groupWorkoutsByDate(workouts);
+
+            return RefreshIndicator(
+              onRefresh: () async {
+                context.read<WorkoutBloc>().add(
+                      const RefreshWorkoutsEvent(),
+                    );
+                await Future.delayed(const Duration(seconds: 1));
+              },
+              child: ListView.builder(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                itemCount: groupedWorkouts.length,
+                itemBuilder: (context, index) {
+                  final entry = groupedWorkouts[index];
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                        child: Text(
+                          entry['date'] as String,
+                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                color: Theme.of(context).colorScheme.primary,
+                              ),
+                        ),
+                      ),
+                      ...((entry['workouts'] as List<WorkoutEntity>).map((workout) {
+                        return WorkoutListItem(
+                          workout: workout,
+                          onTap: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => WorkoutDetailPage(workout: workout),
+                              ),
+                            );
+                          },
+                        );
+                      })),
+                    ],
+                  );
+                },
+              ),
+            );
+          }
+
+          // 초기 상태
+          return const Center(child: CircularProgressIndicator());
+        },
+      ),
+    );
+  }
+
+  void _showFilterSheet() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) => FilterBottomSheet(
+        selectedType: _selectedType,
+        selectedSource: _selectedSource,
+        onApply: (type, source) {
+          setState(() {
+            _selectedType = type;
+            _selectedSource = source;
+          });
+        },
+      ),
+    );
+  }
+
+  List<Map<String, dynamic>> _groupWorkoutsByDate(List<WorkoutEntity> workouts) {
+    final groups = <String, List<WorkoutEntity>>{};
+
+    for (final workout in workouts) {
+      final dateKey = _getDateKey(workout.startTime);
+      if (!groups.containsKey(dateKey)) {
+        groups[dateKey] = [];
+      }
+      groups[dateKey]!.add(workout);
+    }
+
+    final result = groups.entries.map((entry) {
+      return {
+        'date': entry.key,
+        'workouts': entry.value,
+      };
+    }).toList();
+
+    return result;
+  }
+
+  String _getDateKey(DateTime dateTime) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = today.subtract(const Duration(days: 1));
+    final date = DateTime(dateTime.year, dateTime.month, dateTime.day);
+
+    if (date == today) {
+      return '오늘';
+    } else if (date == yesterday) {
+      return '어제';
+    } else if (now.difference(date).inDays < 7) {
+      return '${now.difference(date).inDays}일 전';
+    } else if (date.year == now.year) {
+      return DateFormat('MM월 dd일').format(dateTime);
+    } else {
+      return DateFormat('yyyy년 MM월 dd일').format(dateTime);
+    }
+  }
+}

--- a/lib/features/workout/presentation/widgets/filter_bottom_sheet.dart
+++ b/lib/features/workout/presentation/widgets/filter_bottom_sheet.dart
@@ -1,0 +1,249 @@
+import 'package:flutter/material.dart';
+import 'package:co_workfit/features/workout/domain/entities/workout_entity.dart';
+
+/// 운동 필터 바텀시트
+class FilterBottomSheet extends StatefulWidget {
+  final WorkoutType? selectedType;
+  final WorkoutSource? selectedSource;
+  final Function(WorkoutType?, WorkoutSource?) onApply;
+
+  const FilterBottomSheet({
+    super.key,
+    this.selectedType,
+    this.selectedSource,
+    required this.onApply,
+  });
+
+  @override
+  State<FilterBottomSheet> createState() => _FilterBottomSheetState();
+}
+
+class _FilterBottomSheetState extends State<FilterBottomSheet> {
+  WorkoutType? _selectedType;
+  WorkoutSource? _selectedSource;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedType = widget.selectedType;
+    _selectedSource = widget.selectedSource;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '필터',
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => Navigator.pop(context),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+
+          // 운동 타입 필터
+          Text(
+            '운동 타입',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildTypeChip(null, '전체', Icons.all_inclusive),
+              ...WorkoutType.values.map((type) {
+                return _buildTypeChip(
+                  type,
+                  _getWorkoutTypeName(type),
+                  _getWorkoutIcon(type),
+                );
+              }),
+            ],
+          ),
+          const SizedBox(height: 24),
+
+          // 데이터 소스 필터
+          Text(
+            '데이터 소스',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              _buildSourceChip(null, '전체', Icons.all_inclusive),
+              ...WorkoutSource.values.map((source) {
+                return _buildSourceChip(
+                  source,
+                  _getSourceName(source),
+                  _getSourceIcon(source),
+                );
+              }),
+            ],
+          ),
+          const SizedBox(height: 24),
+
+          // 버튼
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () {
+                    setState(() {
+                      _selectedType = null;
+                      _selectedSource = null;
+                    });
+                  },
+                  child: const Text('초기화'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                flex: 2,
+                child: ElevatedButton(
+                  onPressed: () {
+                    widget.onApply(_selectedType, _selectedSource);
+                    Navigator.pop(context);
+                  },
+                  child: const Text('적용'),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTypeChip(WorkoutType? type, String label, IconData icon) {
+    final isSelected = _selectedType == type;
+    return FilterChip(
+      selected: isSelected,
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18),
+          const SizedBox(width: 6),
+          Text(label),
+        ],
+      ),
+      onSelected: (selected) {
+        setState(() {
+          _selectedType = selected ? type : null;
+        });
+      },
+    );
+  }
+
+  Widget _buildSourceChip(WorkoutSource? source, String label, IconData icon) {
+    final isSelected = _selectedSource == source;
+    return FilterChip(
+      selected: isSelected,
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18),
+          const SizedBox(width: 6),
+          Text(label),
+        ],
+      ),
+      onSelected: (selected) {
+        setState(() {
+          _selectedSource = selected ? source : null;
+        });
+      },
+    );
+  }
+
+  IconData _getWorkoutIcon(WorkoutType type) {
+    switch (type) {
+      case WorkoutType.running:
+        return Icons.directions_run;
+      case WorkoutType.cycling:
+        return Icons.directions_bike;
+      case WorkoutType.walking:
+        return Icons.directions_walk;
+      case WorkoutType.swimming:
+        return Icons.pool;
+      case WorkoutType.weightTraining:
+        return Icons.fitness_center;
+      case WorkoutType.yoga:
+        return Icons.self_improvement;
+      case WorkoutType.hiking:
+        return Icons.terrain;
+      case WorkoutType.other:
+        return Icons.sports;
+    }
+  }
+
+  String _getWorkoutTypeName(WorkoutType type) {
+    switch (type) {
+      case WorkoutType.running:
+        return '러닝';
+      case WorkoutType.cycling:
+        return '사이클링';
+      case WorkoutType.walking:
+        return '걷기';
+      case WorkoutType.swimming:
+        return '수영';
+      case WorkoutType.weightTraining:
+        return '웨이트';
+      case WorkoutType.yoga:
+        return '요가';
+      case WorkoutType.hiking:
+        return '등산';
+      case WorkoutType.other:
+        return '기타';
+    }
+  }
+
+  IconData _getSourceIcon(WorkoutSource source) {
+    switch (source) {
+      case WorkoutSource.appleHealth:
+        return Icons.apple;
+      case WorkoutSource.googleFit:
+        return Icons.android;
+      case WorkoutSource.garmin:
+        return Icons.watch;
+      case WorkoutSource.samsungHealth:
+        return Icons.smartphone;
+      case WorkoutSource.manual:
+        return Icons.edit;
+    }
+  }
+
+  String _getSourceName(WorkoutSource source) {
+    switch (source) {
+      case WorkoutSource.appleHealth:
+        return 'Apple';
+      case WorkoutSource.googleFit:
+        return 'Google Fit';
+      case WorkoutSource.garmin:
+        return 'Garmin';
+      case WorkoutSource.samsungHealth:
+        return 'Samsung';
+      case WorkoutSource.manual:
+        return '수동';
+    }
+  }
+}

--- a/lib/features/workout/presentation/widgets/workout_list_item.dart
+++ b/lib/features/workout/presentation/widgets/workout_list_item.dart
@@ -5,10 +5,12 @@ import 'package:intl/intl.dart';
 /// 운동 리스트 아이템 위젯
 class WorkoutListItem extends StatelessWidget {
   final WorkoutEntity workout;
+  final VoidCallback? onTap;
 
   const WorkoutListItem({
     super.key,
     required this.workout,
+    this.onTap,
   });
 
   @override
@@ -16,9 +18,7 @@ class WorkoutListItem extends StatelessWidget {
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: InkWell(
-        onTap: () {
-          // TODO: 운동 상세 페이지로 이동
-        },
+        onTap: onTap,
         borderRadius: BorderRadius.circular(12),
         child: Padding(
           padding: const EdgeInsets.all(16),


### PR DESCRIPTION
## 📋 개요
Issue #8에 따라 운동 데이터의 전체목록 화면과 상세보기 화면을 구현했습니다.

## ✨ 구현 내용

### 1. 운동 전체목록 페이지 (`WorkoutListPage`)
- ✅ 운동 기록 리스트 표시 (날짜별 그룹핑)
- ✅ 필터링 기능
  - 운동 타입별 필터 (러닝, 사이클링, 걷기, 수영 등)
  - 데이터 소스별 필터 (Apple Health, Google Fit, Garmin 등)
- ✅ 정렬 기능
  - 최신순 / 오래된순
  - 점수 높은순 / 낮은순
- ✅ Pull-to-refresh 지원
- ✅ 빈 상태 및 에러 처리

### 2. 운동 상세보기 페이지 (`WorkoutDetailPage`)
- ✅ 운동 타입 및 아이콘 표시 (헤더)
- ✅ 획득 점수 강조 표시 (그라데이션 카드)
- ✅ 운동 상세 정보
  - 시작/종료 시간
  - 총 시간 (duration)
  - 칼로리, 거리, 심박수, 걸음 수, 고도 상승
- ✅ 캘리브레이션 정보
  - 표준화된 운동 강도
  - 난이도 레벨 (매우 높음 🔥🔥🔥 ~ 매우 낮음 ⚡)
  - 플랫폼 보정 정보
- ✅ 데이터 소스 정보 (아이콘 및 설명)

### 3. 필터 바텀시트 (`FilterBottomSheet`)
- ✅ 운동 타입별 FilterChip
- ✅ 데이터 소스별 FilterChip
- ✅ 필터 초기화 기능
- ✅ 적용 버튼

### 4. 기존 코드 개선
- ✅ `WorkoutListItem`에 `onTap` 콜백 추가
- ✅ `DashboardPage`에서 전체보기 버튼 클릭 시 `WorkoutListPage`로 이동
- ✅ `DashboardPage`에서 운동 아이템 클릭 시 `WorkoutDetailPage`로 이동

## 📁 변경된 파일
- 🆕 `lib/features/workout/presentation/pages/workout_list_page.dart`
- 🆕 `lib/features/workout/presentation/pages/workout_detail_page.dart`
- 🆕 `lib/features/workout/presentation/widgets/filter_bottom_sheet.dart`
- 🔧 `lib/features/workout/presentation/pages/dashboard_page.dart`
- 🔧 `lib/features/workout/presentation/widgets/workout_list_item.dart`

## 🎨 UI/UX 특징
- 날짜별 그룹핑으로 가독성 향상 (오늘, 어제, N일 전, MM월 dd일)
- 운동 타입별 색상 및 아이콘으로 시각적 구분
- 점수를 강조하여 사용자 동기 부여
- 난이도 이모지로 직관적인 정보 전달
- 빈 상태 및 필터링 결과 없음 처리

## 🔗 관련 Issue
Closes #8

## 🧪 테스트 체크리스트
- [ ] 운동 목록 페이지 진입
- [ ] 날짜별 그룹핑 확인
- [ ] 필터 적용 (타입, 소스)
- [ ] 정렬 변경 (최신순, 점수순 등)
- [ ] 운동 아이템 클릭 → 상세 페이지 이동
- [ ] 상세 페이지에서 모든 정보 표시 확인
- [ ] Pull-to-refresh 동작 확인
- [ ] 대시보드에서 "전체보기" 버튼 클릭

## 📸 스크린샷
(TODO: 테스트 후 스크린샷 추가 예정)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>