### PR TITLE
[Phase 4] 친구 관리 UI 구현

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -36,11 +36,22 @@ import 'package:co_workfit/features/profile/data/repositories/profile_repository
 import 'package:co_workfit/features/profile/domain/repositories/profile_repository.dart';
 import 'package:co_workfit/features/profile/domain/usecases/get_profile_data.dart';
 import 'package:co_workfit/features/profile/domain/usecases/logout_user.dart';
-import 'package:co_workfit/features/profile/domain/usecases/update_display_name_use_case.dart';
+import 'package:co_workfit/features/profile/domain/usecases/update_display_name.dart';
 import 'package:co_workfit/features/profile/presentation/bloc/profile_bloc.dart';
 
 // Social
 import 'package:co_workfit/features/social/data/datasources/firestore_social_datasource.dart';
+import 'package:co_workfit/features/social/data/repositories/social_repository_impl.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+import 'package:co_workfit/features/social/domain/usecases/get_friends.dart';
+import 'package:co_workfit/features/social/domain/usecases/send_friend_request.dart';
+import 'package:co_workfit/features/social/domain/usecases/get_received_friend_requests.dart';
+import 'package:co_workfit/features/social/domain/usecases/get_sent_friend_requests.dart';
+import 'package:co_workfit/features/social/domain/usecases/accept_friend_request.dart';
+import 'package:co_workfit/features/social/domain/usecases/reject_friend_request.dart';
+import 'package:co_workfit/features/social/domain/usecases/cancel_friend_request.dart';
+import 'package:co_workfit/features/social/domain/usecases/search_users_by_email.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_bloc.dart';
 
 final sl = GetIt.instance;
 
@@ -177,5 +188,34 @@ Future<void> initializeDependencies() async {
   // Data Sources
   sl.registerLazySingleton<FirestoreSocialDataSource>(
     () => FirestoreSocialDataSource(),
+  );
+
+  // Repository
+  sl.registerLazySingleton<SocialRepository>(
+    () => SocialRepositoryImpl(sl()),
+  );
+
+  // Use Cases
+  sl.registerLazySingleton(() => GetFriends(sl()));
+  sl.registerLazySingleton(() => SendFriendRequest(sl()));
+  sl.registerLazySingleton(() => GetReceivedFriendRequests(sl()));
+  sl.registerLazySingleton(() => GetSentFriendRequests(sl()));
+  sl.registerLazySingleton(() => AcceptFriendRequest(sl()));
+  sl.registerLazySingleton(() => RejectFriendRequest(sl()));
+  sl.registerLazySingleton(() => CancelFriendRequest(sl()));
+  sl.registerLazySingleton(() => SearchUsersByEmail(sl()));
+
+  // BLoC
+  sl.registerFactory(
+    () => SocialBloc(
+      getFriends: sl(),
+      sendFriendRequest: sl(),
+      getReceivedFriendRequests: sl(),
+      getSentFriendRequests: sl(),
+      acceptFriendRequest: sl(),
+      rejectFriendRequest: sl(),
+      cancelFriendRequest: sl(),
+      searchUsersByEmail: sl(),
+    ),
   );
 }

--- a/lib/features/profile/presentation/bloc/profile_bloc.dart
+++ b/lib/features/profile/presentation/bloc/profile_bloc.dart
@@ -2,19 +2,19 @@ import 'package:bloc/bloc.dart';
 import 'package:co_workfit/core/errors/failure.dart';
 import 'package:co_workfit/features/profile/domain/usecases/get_profile_data.dart';
 import 'package:co_workfit/features/profile/domain/usecases/logout_user.dart';
-import 'package:co_workfit/features/profile/domain/usecases/update_display_name_use_case.dart';
+import 'package:co_workfit/features/profile/domain/usecases/update_display_name.dart' as usecases;
 
 import 'profile_event.dart';
 import 'profile_state.dart';
 
 class ProfileBloc extends Bloc<ProfileEvent, ProfileState> {
   final GetProfileData _getProfileDataUseCase;
-  final UpdateDisplayNameUseCase _updateDisplayNameUseCase;
+  final usecases.UpdateDisplayName _updateDisplayNameUseCase;
   final LogoutUser _logoutUserUseCase;
 
   ProfileBloc({
     required GetProfileData getProfileData,
-    required UpdateDisplayNameUseCase updateDisplayName,
+    required usecases.UpdateDisplayName updateDisplayName,
     required LogoutUser logoutUser,
   })  : _getProfileDataUseCase = getProfileData,
         _updateDisplayNameUseCase = updateDisplayName,

--- a/lib/features/social/data/repositories/social_repository_impl.dart
+++ b/lib/features/social/data/repositories/social_repository_impl.dart
@@ -1,0 +1,215 @@
+import 'package:dartz/dartz.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/auth/domain/entities/user_entity.dart';
+import 'package:co_workfit/features/auth/data/models/user_model.dart';
+import 'package:co_workfit/features/social/domain/entities/friend_request_entity.dart';
+import 'package:co_workfit/features/social/domain/entities/friendship_entity.dart';
+import 'package:co_workfit/features/social/domain/entities/leaderboard_entry_entity.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+import 'package:co_workfit/features/social/data/datasources/firestore_social_datasource.dart';
+
+class SocialRepositoryImpl implements SocialRepository {
+  final FirestoreSocialDataSource dataSource;
+
+  SocialRepositoryImpl(this.dataSource);
+
+  @override
+  Future<Either<Failure, void>> sendFriendRequest({
+    required String senderId,
+    required String senderName,
+    String? senderPhotoUrl,
+    required String receiverId,
+  }) async {
+    try {
+      final result = await dataSource.sendFriendRequest(
+        senderId: senderId,
+        senderName: senderName,
+        senderPhotoUrl: senderPhotoUrl,
+        receiverId: receiverId,
+      );
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (_) => const Right(null),
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<FriendRequestEntity>>> getReceivedFriendRequests(
+    String userId,
+  ) async {
+    try {
+      final result = await dataSource.getReceivedFriendRequests(userId);
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (requests) => Right(requests),
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<FriendRequestEntity>>> getSentFriendRequests(
+    String userId,
+  ) async {
+    try {
+      final result = await dataSource.getSentFriendRequests(userId);
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (requests) => Right(requests),
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> acceptFriendRequest(String requestId) async {
+    try {
+      final result = await dataSource.acceptFriendRequest(requestId);
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (_) => const Right(null),
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> rejectFriendRequest(String requestId) async {
+    try {
+      final result = await dataSource.rejectFriendRequest(requestId);
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (_) => const Right(null),
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> cancelFriendRequest(String requestId) async {
+    try {
+      final result = await dataSource.cancelFriendRequest(requestId);
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (_) => const Right(null),
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<FriendshipEntity>>> getFriends(
+    String userId,
+  ) async {
+    try {
+      final result = await dataSource.getFriends(userId);
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (friends) => Right(friends),
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, void>> removeFriend({
+    required String userId,
+    required String friendId,
+  }) async {
+    try {
+      final result = await dataSource.removeFriend(
+        userId: userId,
+        friendId: friendId,
+      );
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (_) => const Right(null),
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<LeaderboardEntryEntity>>> getLeaderboard({
+    required LeaderboardType type,
+    int limit = 50,
+  }) async {
+    try {
+      final result = await dataSource.getLeaderboard(
+        type: type,
+        limit: limit,
+      );
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (entries) => Right(entries),
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<LeaderboardEntryEntity>>> getFriendsLeaderboard({
+    required String userId,
+    required LeaderboardType type,
+  }) async {
+    try {
+      final result = await dataSource.getFriendsLeaderboard(
+        userId: userId,
+        type: type,
+      );
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (entries) => Right(entries),
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<UserEntity>>> searchUsersByEmail(
+    String email,
+  ) async {
+    try {
+      final result = await dataSource.searchUsersByEmail(email);
+      return result.fold(
+        (error) => Left(ServerFailure(error)),
+        (usersData) {
+          final users = usersData.map((data) {
+            return UserModel(
+              id: data['id'] as String,
+              email: data['email'] as String,
+              displayName: data['displayName'] as String,
+              photoUrl: data['photoUrl'] as String?,
+              totalScore: (data['totalScore'] as num?)?.toInt() ?? 0,
+              workoutCount: (data['workoutCount'] as num?)?.toInt() ?? 0,
+              createdAt: data['createdAt'] is Timestamp
+                  ? (data['createdAt'] as Timestamp).toDate()
+                  : DateTime.parse(data['createdAt'] as String),
+              lastActiveAt: data['lastActiveAt'] != null
+                  ? (data['lastActiveAt'] is Timestamp
+                      ? (data['lastActiveAt'] as Timestamp).toDate()
+                      : DateTime.parse(data['lastActiveAt'] as String))
+                  : null,
+            );
+          }).toList();
+          return Right(users);
+        },
+      );
+    } catch (e) {
+      return Left(ServerFailure(e.toString()));
+    }
+  }
+}

--- a/lib/features/social/domain/repositories/social_repository.dart
+++ b/lib/features/social/domain/repositories/social_repository.dart
@@ -1,0 +1,52 @@
+import 'package:dartz/dartz.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/auth/domain/entities/user_entity.dart';
+import 'package:co_workfit/features/social/domain/entities/friend_request_entity.dart';
+import 'package:co_workfit/features/social/domain/entities/friendship_entity.dart';
+import 'package:co_workfit/features/social/domain/entities/leaderboard_entry_entity.dart';
+
+abstract class SocialRepository {
+  // Friend Request Methods
+  Future<Either<Failure, void>> sendFriendRequest({
+    required String senderId,
+    required String senderName,
+    String? senderPhotoUrl,
+    required String receiverId,
+  });
+
+  Future<Either<Failure, List<FriendRequestEntity>>> getReceivedFriendRequests(
+    String userId,
+  );
+
+  Future<Either<Failure, List<FriendRequestEntity>>> getSentFriendRequests(
+    String userId,
+  );
+
+  Future<Either<Failure, void>> acceptFriendRequest(String requestId);
+
+  Future<Either<Failure, void>> rejectFriendRequest(String requestId);
+
+  Future<Either<Failure, void>> cancelFriendRequest(String requestId);
+
+  // Friend Management Methods
+  Future<Either<Failure, List<FriendshipEntity>>> getFriends(String userId);
+
+  Future<Either<Failure, void>> removeFriend({
+    required String userId,
+    required String friendId,
+  });
+
+  // Leaderboard Methods
+  Future<Either<Failure, List<LeaderboardEntryEntity>>> getLeaderboard({
+    required LeaderboardType type,
+    int limit = 50,
+  });
+
+  Future<Either<Failure, List<LeaderboardEntryEntity>>> getFriendsLeaderboard({
+    required String userId,
+    required LeaderboardType type,
+  });
+
+  // User Search
+  Future<Either<Failure, List<UserEntity>>> searchUsersByEmail(String email);
+}

--- a/lib/features/social/domain/usecases/accept_friend_request.dart
+++ b/lib/features/social/domain/usecases/accept_friend_request.dart
@@ -1,0 +1,13 @@
+import 'package:dartz/dartz.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+
+class AcceptFriendRequest {
+  final SocialRepository repository;
+
+  AcceptFriendRequest(this.repository);
+
+  Future<Either<Failure, void>> call(String requestId) async {
+    return await repository.acceptFriendRequest(requestId);
+  }
+}

--- a/lib/features/social/domain/usecases/cancel_friend_request.dart
+++ b/lib/features/social/domain/usecases/cancel_friend_request.dart
@@ -1,0 +1,13 @@
+import 'package:dartz/dartz.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+
+class CancelFriendRequest {
+  final SocialRepository repository;
+
+  CancelFriendRequest(this.repository);
+
+  Future<Either<Failure, void>> call(String requestId) async {
+    return await repository.cancelFriendRequest(requestId);
+  }
+}

--- a/lib/features/social/domain/usecases/get_friends.dart
+++ b/lib/features/social/domain/usecases/get_friends.dart
@@ -1,0 +1,14 @@
+import 'package:dartz/dartz.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/social/domain/entities/friendship_entity.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+
+class GetFriends {
+  final SocialRepository repository;
+
+  GetFriends(this.repository);
+
+  Future<Either<Failure, List<FriendshipEntity>>> call(String userId) async {
+    return await repository.getFriends(userId);
+  }
+}

--- a/lib/features/social/domain/usecases/get_received_friend_requests.dart
+++ b/lib/features/social/domain/usecases/get_received_friend_requests.dart
@@ -1,0 +1,14 @@
+import 'package:dartz/dartz.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/social/domain/entities/friend_request_entity.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+
+class GetReceivedFriendRequests {
+  final SocialRepository repository;
+
+  GetReceivedFriendRequests(this.repository);
+
+  Future<Either<Failure, List<FriendRequestEntity>>> call(String userId) async {
+    return await repository.getReceivedFriendRequests(userId);
+  }
+}

--- a/lib/features/social/domain/usecases/get_sent_friend_requests.dart
+++ b/lib/features/social/domain/usecases/get_sent_friend_requests.dart
@@ -1,0 +1,14 @@
+import 'package:dartz/dartz.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/social/domain/entities/friend_request_entity.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+
+class GetSentFriendRequests {
+  final SocialRepository repository;
+
+  GetSentFriendRequests(this.repository);
+
+  Future<Either<Failure, List<FriendRequestEntity>>> call(String userId) async {
+    return await repository.getSentFriendRequests(userId);
+  }
+}

--- a/lib/features/social/domain/usecases/reject_friend_request.dart
+++ b/lib/features/social/domain/usecases/reject_friend_request.dart
@@ -1,0 +1,13 @@
+import 'package:dartz/dartz.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+
+class RejectFriendRequest {
+  final SocialRepository repository;
+
+  RejectFriendRequest(this.repository);
+
+  Future<Either<Failure, void>> call(String requestId) async {
+    return await repository.rejectFriendRequest(requestId);
+  }
+}

--- a/lib/features/social/domain/usecases/search_users_by_email.dart
+++ b/lib/features/social/domain/usecases/search_users_by_email.dart
@@ -1,0 +1,14 @@
+import 'package:dartz/dartz.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/auth/domain/entities/user_entity.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+
+class SearchUsersByEmail {
+  final SocialRepository repository;
+
+  SearchUsersByEmail(this.repository);
+
+  Future<Either<Failure, List<UserEntity>>> call(String email) async {
+    return await repository.searchUsersByEmail(email);
+  }
+}

--- a/lib/features/social/domain/usecases/send_friend_request.dart
+++ b/lib/features/social/domain/usecases/send_friend_request.dart
@@ -1,0 +1,23 @@
+import 'package:dartz/dartz.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+
+class SendFriendRequest {
+  final SocialRepository repository;
+
+  SendFriendRequest(this.repository);
+
+  Future<Either<Failure, void>> call({
+    required String senderId,
+    required String senderName,
+    String? senderPhotoUrl,
+    required String receiverId,
+  }) async {
+    return await repository.sendFriendRequest(
+      senderId: senderId,
+      senderName: senderName,
+      senderPhotoUrl: senderPhotoUrl,
+      receiverId: receiverId,
+    );
+  }
+}

--- a/lib/features/social/presentation/bloc/social_bloc.dart
+++ b/lib/features/social/presentation/bloc/social_bloc.dart
@@ -1,0 +1,330 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_event.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_state.dart';
+import 'package:co_workfit/features/social/domain/usecases/get_friends.dart';
+import 'package:co_workfit/features/social/domain/usecases/send_friend_request.dart';
+import 'package:co_workfit/features/social/domain/usecases/get_received_friend_requests.dart';
+import 'package:co_workfit/features/social/domain/usecases/get_sent_friend_requests.dart';
+import 'package:co_workfit/features/social/domain/usecases/accept_friend_request.dart';
+import 'package:co_workfit/features/social/domain/usecases/reject_friend_request.dart';
+import 'package:co_workfit/features/social/domain/usecases/cancel_friend_request.dart';
+import 'package:co_workfit/features/social/domain/usecases/search_users_by_email.dart';
+
+class SocialBloc extends Bloc<SocialEvent, SocialState> {
+  final GetFriends getFriends;
+  final SendFriendRequest sendFriendRequest;
+  final GetReceivedFriendRequests getReceivedFriendRequests;
+  final GetSentFriendRequests getSentFriendRequests;
+  final AcceptFriendRequest acceptFriendRequest;
+  final RejectFriendRequest rejectFriendRequest;
+  final CancelFriendRequest cancelFriendRequest;
+  final SearchUsersByEmail searchUsersByEmail;
+
+  SocialBloc({
+    required this.getFriends,
+    required this.sendFriendRequest,
+    required this.getReceivedFriendRequests,
+    required this.getSentFriendRequests,
+    required this.acceptFriendRequest,
+    required this.rejectFriendRequest,
+    required this.cancelFriendRequest,
+    required this.searchUsersByEmail,
+  }) : super(const SocialInitial()) {
+    on<LoadFriends>(_onLoadFriends);
+    on<RefreshFriends>(_onRefreshFriends);
+    on<LoadReceivedFriendRequests>(_onLoadReceivedFriendRequests);
+    on<LoadSentFriendRequests>(_onLoadSentFriendRequests);
+    on<SendFriendRequestEvent>(_onSendFriendRequest);
+    on<AcceptFriendRequestEvent>(_onAcceptFriendRequest);
+    on<RejectFriendRequestEvent>(_onRejectFriendRequest);
+    on<CancelFriendRequestEvent>(_onCancelFriendRequest);
+    on<SearchUsersByEmailEvent>(_onSearchUsersByEmail);
+    on<ClearSearchResults>(_onClearSearchResults);
+  }
+
+  Future<void> _onLoadFriends(
+    LoadFriends event,
+    Emitter<SocialState> emit,
+  ) async {
+    emit(const SocialLoading());
+
+    final result = await getFriends(event.userId);
+
+    result.fold(
+      (failure) => emit(SocialError(failure.message)),
+      (friends) => emit(SocialLoaded(friends: friends)),
+    );
+  }
+
+  Future<void> _onRefreshFriends(
+    RefreshFriends event,
+    Emitter<SocialState> emit,
+  ) async {
+    final currentState = state;
+    if (currentState is SocialLoaded) {
+      final result = await getFriends(event.userId);
+
+      result.fold(
+        (failure) => emit(SocialError(failure.message, previousState: currentState)),
+        (friends) => emit(currentState.copyWith(friends: friends)),
+      );
+    }
+  }
+
+  Future<void> _onLoadReceivedFriendRequests(
+    LoadReceivedFriendRequests event,
+    Emitter<SocialState> emit,
+  ) async {
+    final currentState = state;
+
+    final result = await getReceivedFriendRequests(event.userId);
+
+    result.fold(
+      (failure) {
+        if (currentState is SocialLoaded) {
+          emit(SocialError(failure.message, previousState: currentState));
+        } else {
+          emit(SocialError(failure.message));
+        }
+      },
+      (requests) {
+        if (currentState is SocialLoaded) {
+          emit(currentState.copyWith(receivedRequests: requests));
+        } else {
+          emit(SocialLoaded(receivedRequests: requests));
+        }
+      },
+    );
+  }
+
+  Future<void> _onLoadSentFriendRequests(
+    LoadSentFriendRequests event,
+    Emitter<SocialState> emit,
+  ) async {
+    final currentState = state;
+
+    final result = await getSentFriendRequests(event.userId);
+
+    result.fold(
+      (failure) {
+        if (currentState is SocialLoaded) {
+          emit(SocialError(failure.message, previousState: currentState));
+        } else {
+          emit(SocialError(failure.message));
+        }
+      },
+      (requests) {
+        if (currentState is SocialLoaded) {
+          emit(currentState.copyWith(sentRequests: requests));
+        } else {
+          emit(SocialLoaded(sentRequests: requests));
+        }
+      },
+    );
+  }
+
+  Future<void> _onSendFriendRequest(
+    SendFriendRequestEvent event,
+    Emitter<SocialState> emit,
+  ) async {
+    final currentState = state;
+
+    if (currentState is SocialLoaded) {
+      emit(SocialActionInProgress(
+        currentState: currentState,
+        actionType: 'send_request',
+      ));
+    }
+
+    final result = await sendFriendRequest(
+      senderId: event.senderId,
+      senderName: event.senderName,
+      senderPhotoUrl: event.senderPhotoUrl,
+      receiverId: event.receiverId,
+    );
+
+    result.fold(
+      (failure) {
+        if (currentState is SocialLoaded) {
+          emit(SocialError(failure.message, previousState: currentState));
+        } else {
+          emit(SocialError(failure.message));
+        }
+      },
+      (_) {
+        if (currentState is SocialLoaded) {
+          emit(SocialActionSuccess(
+            newState: currentState.copyWith(searchResults: []),
+            message: '친구 요청을 보냈습니다',
+          ));
+        } else {
+          emit(const SocialLoaded());
+        }
+      },
+    );
+  }
+
+  Future<void> _onAcceptFriendRequest(
+    AcceptFriendRequestEvent event,
+    Emitter<SocialState> emit,
+  ) async {
+    final currentState = state;
+
+    if (currentState is SocialLoaded) {
+      emit(SocialActionInProgress(
+        currentState: currentState,
+        actionType: 'accept_request',
+      ));
+    }
+
+    final result = await acceptFriendRequest(event.requestId);
+
+    result.fold(
+      (failure) {
+        if (currentState is SocialLoaded) {
+          emit(SocialError(failure.message, previousState: currentState));
+        } else {
+          emit(SocialError(failure.message));
+        }
+      },
+      (_) {
+        if (currentState is SocialLoaded) {
+          final updatedRequests = currentState.receivedRequests
+              .where((req) => req.id != event.requestId)
+              .toList();
+
+          emit(SocialActionSuccess(
+            newState: currentState.copyWith(receivedRequests: updatedRequests),
+            message: '친구 요청을 수락했습니다',
+          ));
+        } else {
+          emit(const SocialLoaded());
+        }
+      },
+    );
+  }
+
+  Future<void> _onRejectFriendRequest(
+    RejectFriendRequestEvent event,
+    Emitter<SocialState> emit,
+  ) async {
+    final currentState = state;
+
+    if (currentState is SocialLoaded) {
+      emit(SocialActionInProgress(
+        currentState: currentState,
+        actionType: 'reject_request',
+      ));
+    }
+
+    final result = await rejectFriendRequest(event.requestId);
+
+    result.fold(
+      (failure) {
+        if (currentState is SocialLoaded) {
+          emit(SocialError(failure.message, previousState: currentState));
+        } else {
+          emit(SocialError(failure.message));
+        }
+      },
+      (_) {
+        if (currentState is SocialLoaded) {
+          final updatedRequests = currentState.receivedRequests
+              .where((req) => req.id != event.requestId)
+              .toList();
+
+          emit(SocialActionSuccess(
+            newState: currentState.copyWith(receivedRequests: updatedRequests),
+            message: '친구 요청을 거절했습니다',
+          ));
+        } else {
+          emit(const SocialLoaded());
+        }
+      },
+    );
+  }
+
+  Future<void> _onCancelFriendRequest(
+    CancelFriendRequestEvent event,
+    Emitter<SocialState> emit,
+  ) async {
+    final currentState = state;
+
+    if (currentState is SocialLoaded) {
+      emit(SocialActionInProgress(
+        currentState: currentState,
+        actionType: 'cancel_request',
+      ));
+    }
+
+    final result = await cancelFriendRequest(event.requestId);
+
+    result.fold(
+      (failure) {
+        if (currentState is SocialLoaded) {
+          emit(SocialError(failure.message, previousState: currentState));
+        } else {
+          emit(SocialError(failure.message));
+        }
+      },
+      (_) {
+        if (currentState is SocialLoaded) {
+          final updatedRequests = currentState.sentRequests
+              .where((req) => req.id != event.requestId)
+              .toList();
+
+          emit(SocialActionSuccess(
+            newState: currentState.copyWith(sentRequests: updatedRequests),
+            message: '친구 요청을 취소했습니다',
+          ));
+        } else {
+          emit(const SocialLoaded());
+        }
+      },
+    );
+  }
+
+  Future<void> _onSearchUsersByEmail(
+    SearchUsersByEmailEvent event,
+    Emitter<SocialState> emit,
+  ) async {
+    final currentState = state;
+
+    if (currentState is SocialLoaded) {
+      emit(SocialActionInProgress(
+        currentState: currentState,
+        actionType: 'search_users',
+      ));
+    }
+
+    final result = await searchUsersByEmail(event.email);
+
+    result.fold(
+      (failure) {
+        if (currentState is SocialLoaded) {
+          emit(SocialError(failure.message, previousState: currentState));
+        } else {
+          emit(SocialError(failure.message));
+        }
+      },
+      (users) {
+        if (currentState is SocialLoaded) {
+          emit(currentState.copyWith(searchResults: users));
+        } else {
+          emit(SocialLoaded(searchResults: users));
+        }
+      },
+    );
+  }
+
+  Future<void> _onClearSearchResults(
+    ClearSearchResults event,
+    Emitter<SocialState> emit,
+  ) async {
+    final currentState = state;
+
+    if (currentState is SocialLoaded) {
+      emit(currentState.copyWith(searchResults: []));
+    }
+  }
+}

--- a/lib/features/social/presentation/bloc/social_event.dart
+++ b/lib/features/social/presentation/bloc/social_event.dart
@@ -1,0 +1,104 @@
+import 'package:equatable/equatable.dart';
+
+abstract class SocialEvent extends Equatable {
+  const SocialEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+// Friends Events
+class LoadFriends extends SocialEvent {
+  final String userId;
+
+  const LoadFriends(this.userId);
+
+  @override
+  List<Object?> get props => [userId];
+}
+
+class RefreshFriends extends SocialEvent {
+  final String userId;
+
+  const RefreshFriends(this.userId);
+
+  @override
+  List<Object?> get props => [userId];
+}
+
+// Friend Request Events
+class LoadReceivedFriendRequests extends SocialEvent {
+  final String userId;
+
+  const LoadReceivedFriendRequests(this.userId);
+
+  @override
+  List<Object?> get props => [userId];
+}
+
+class LoadSentFriendRequests extends SocialEvent {
+  final String userId;
+
+  const LoadSentFriendRequests(this.userId);
+
+  @override
+  List<Object?> get props => [userId];
+}
+
+class SendFriendRequestEvent extends SocialEvent {
+  final String senderId;
+  final String senderName;
+  final String? senderPhotoUrl;
+  final String receiverId;
+
+  const SendFriendRequestEvent({
+    required this.senderId,
+    required this.senderName,
+    this.senderPhotoUrl,
+    required this.receiverId,
+  });
+
+  @override
+  List<Object?> get props => [senderId, senderName, senderPhotoUrl, receiverId];
+}
+
+class AcceptFriendRequestEvent extends SocialEvent {
+  final String requestId;
+
+  const AcceptFriendRequestEvent(this.requestId);
+
+  @override
+  List<Object?> get props => [requestId];
+}
+
+class RejectFriendRequestEvent extends SocialEvent {
+  final String requestId;
+
+  const RejectFriendRequestEvent(this.requestId);
+
+  @override
+  List<Object?> get props => [requestId];
+}
+
+class CancelFriendRequestEvent extends SocialEvent {
+  final String requestId;
+
+  const CancelFriendRequestEvent(this.requestId);
+
+  @override
+  List<Object?> get props => [requestId];
+}
+
+// User Search Events
+class SearchUsersByEmailEvent extends SocialEvent {
+  final String email;
+
+  const SearchUsersByEmailEvent(this.email);
+
+  @override
+  List<Object?> get props => [email];
+}
+
+class ClearSearchResults extends SocialEvent {
+  const ClearSearchResults();
+}

--- a/lib/features/social/presentation/bloc/social_state.dart
+++ b/lib/features/social/presentation/bloc/social_state.dart
@@ -1,0 +1,86 @@
+import 'package:equatable/equatable.dart';
+import 'package:co_workfit/features/auth/domain/entities/user_entity.dart';
+import 'package:co_workfit/features/social/domain/entities/friend_request_entity.dart';
+import 'package:co_workfit/features/social/domain/entities/friendship_entity.dart';
+
+abstract class SocialState extends Equatable {
+  const SocialState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class SocialInitial extends SocialState {
+  const SocialInitial();
+}
+
+class SocialLoading extends SocialState {
+  const SocialLoading();
+}
+
+class SocialLoaded extends SocialState {
+  final List<FriendshipEntity> friends;
+  final List<FriendRequestEntity> receivedRequests;
+  final List<FriendRequestEntity> sentRequests;
+  final List<UserEntity> searchResults;
+
+  const SocialLoaded({
+    this.friends = const [],
+    this.receivedRequests = const [],
+    this.sentRequests = const [],
+    this.searchResults = const [],
+  });
+
+  @override
+  List<Object?> get props => [friends, receivedRequests, sentRequests, searchResults];
+
+  SocialLoaded copyWith({
+    List<FriendshipEntity>? friends,
+    List<FriendRequestEntity>? receivedRequests,
+    List<FriendRequestEntity>? sentRequests,
+    List<UserEntity>? searchResults,
+  }) {
+    return SocialLoaded(
+      friends: friends ?? this.friends,
+      receivedRequests: receivedRequests ?? this.receivedRequests,
+      sentRequests: sentRequests ?? this.sentRequests,
+      searchResults: searchResults ?? this.searchResults,
+    );
+  }
+}
+
+class SocialActionInProgress extends SocialState {
+  final SocialLoaded currentState;
+  final String actionType;
+
+  const SocialActionInProgress({
+    required this.currentState,
+    required this.actionType,
+  });
+
+  @override
+  List<Object?> get props => [currentState, actionType];
+}
+
+class SocialActionSuccess extends SocialState {
+  final SocialLoaded newState;
+  final String message;
+
+  const SocialActionSuccess({
+    required this.newState,
+    required this.message,
+  });
+
+  @override
+  List<Object?> get props => [newState, message];
+}
+
+class SocialError extends SocialState {
+  final String message;
+  final SocialLoaded? previousState;
+
+  const SocialError(this.message, {this.previousState});
+
+  @override
+  List<Object?> get props => [message, previousState];
+}

--- a/lib/features/social/presentation/pages/friends_page.dart
+++ b/lib/features/social/presentation/pages/friends_page.dart
@@ -1,13 +1,95 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_event.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_state.dart';
+import 'package:co_workfit/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:co_workfit/features/auth/presentation/bloc/auth_state.dart';
+import 'package:co_workfit/features/social/presentation/widgets/friends_list_tab.dart';
+import 'package:co_workfit/features/social/presentation/widgets/add_friend_tab.dart';
+import 'package:co_workfit/features/social/presentation/widgets/received_requests_tab.dart';
+import 'package:co_workfit/features/social/presentation/widgets/sent_requests_tab.dart';
 
-class FriendsPage extends StatelessWidget {
+class FriendsPage extends StatefulWidget {
   const FriendsPage({super.key});
 
   @override
+  State<FriendsPage> createState() => _FriendsPageState();
+}
+
+class _FriendsPageState extends State<FriendsPage> with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 4, vsync: this);
+    _loadInitialData();
+  }
+
+  void _loadInitialData() {
+    final authState = context.read<AuthBloc>().state;
+    if (authState is Authenticated) {
+      final userId = authState.user.id;
+      context.read<SocialBloc>().add(LoadFriends(userId));
+      context.read<SocialBloc>().add(LoadReceivedFriendRequests(userId));
+      context.read<SocialBloc>().add(LoadSentFriendRequests(userId));
+    }
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('Friends Page - Coming Soon!'),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('친구'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: '친구 목록'),
+            Tab(text: '친구 추가'),
+            Tab(text: '받은 요청'),
+            Tab(text: '보낸 요청'),
+          ],
+        ),
+      ),
+      body: BlocListener<SocialBloc, SocialState>(
+        listener: (context, state) {
+          if (state is SocialActionSuccess) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(state.message)),
+            );
+            // Reload data after successful action
+            final authState = context.read<AuthBloc>().state;
+            if (authState is Authenticated) {
+              final userId = authState.user.id;
+              context.read<SocialBloc>().add(LoadFriends(userId));
+              context.read<SocialBloc>().add(LoadReceivedFriendRequests(userId));
+              context.read<SocialBloc>().add(LoadSentFriendRequests(userId));
+            }
+          } else if (state is SocialError) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(
+                content: Text(state.message),
+                backgroundColor: Colors.red,
+              ),
+            );
+          }
+        },
+        child: TabBarView(
+          controller: _tabController,
+          children: const [
+            FriendsListTab(),
+            AddFriendTab(),
+            ReceivedRequestsTab(),
+            SentRequestsTab(),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/social/presentation/widgets/add_friend_tab.dart
+++ b/lib/features/social/presentation/widgets/add_friend_tab.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_state.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_event.dart';
+import 'package:co_workfit/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:co_workfit/features/auth/presentation/bloc/auth_state.dart';
+
+class AddFriendTab extends StatefulWidget {
+  const AddFriendTab({super.key});
+
+  @override
+  State<AddFriendTab> createState() => _AddFriendTabState();
+}
+
+class _AddFriendTabState extends State<AddFriendTab> {
+  final TextEditingController _emailController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  void _searchUsers() {
+    final email = _emailController.text.trim();
+    if (email.isNotEmpty) {
+      context.read<SocialBloc>().add(SearchUsersByEmailEvent(email));
+    }
+  }
+
+  void _sendFriendRequest(String receiverId) {
+    final authState = context.read<AuthBloc>().state;
+    if (authState is Authenticated) {
+      context.read<SocialBloc>().add(
+        SendFriendRequestEvent(
+          senderId: authState.user.id,
+          senderName: authState.user.displayName,
+          senderPhotoUrl: authState.user.photoUrl,
+          receiverId: receiverId,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SocialBloc, SocialState>(
+      builder: (context, state) {
+        final searchResults = state is SocialLoaded
+            ? state.searchResults
+            : state is SocialActionSuccess
+                ? state.newState.searchResults
+                : state is SocialActionInProgress
+                    ? state.currentState.searchResults
+                    : <dynamic>[];
+
+        final isSearching = state is SocialActionInProgress &&
+            state.actionType == 'search_users';
+
+        final authState = context.read<AuthBloc>().state;
+        final currentUserId = authState is Authenticated ? authState.user.id : null;
+
+        return Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              TextField(
+                controller: _emailController,
+                decoration: InputDecoration(
+                  labelText: '이메일로 검색',
+                  hintText: 'example@email.com',
+                  prefixIcon: const Icon(Icons.search),
+                  border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    icon: const Icon(Icons.clear),
+                    onPressed: () {
+                      _emailController.clear();
+                      context.read<SocialBloc>().add(const ClearSearchResults());
+                    },
+                  ),
+                ),
+                onSubmitted: (_) => _searchUsers(),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: isSearching ? null : _searchUsers,
+                child: isSearching
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('검색'),
+              ),
+              const SizedBox(height: 24),
+              if (searchResults.isEmpty && !isSearching)
+                const Expanded(
+                  child: Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.person_search, size: 64, color: Colors.grey),
+                        SizedBox(height: 16),
+                        Text(
+                          '이메일로 친구를 검색하세요',
+                          style: TextStyle(fontSize: 18, color: Colors.grey),
+                        ),
+                      ],
+                    ),
+                  ),
+                )
+              else
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: searchResults.length,
+                    itemBuilder: (context, index) {
+                      final user = searchResults[index];
+                      final isCurrentUser = user.id == currentUserId;
+
+                      return Card(
+                        margin: const EdgeInsets.symmetric(vertical: 8),
+                        child: ListTile(
+                          leading: CircleAvatar(
+                            backgroundImage: user.photoUrl != null
+                                ? NetworkImage(user.photoUrl!)
+                                : null,
+                            child: user.photoUrl == null
+                                ? Text(user.displayName[0].toUpperCase())
+                                : null,
+                          ),
+                          title: Text(user.displayName),
+                          subtitle: Text(user.email),
+                          trailing: isCurrentUser
+                              ? const Chip(
+                                  label: Text('나'),
+                                  backgroundColor: Colors.blue,
+                                )
+                              : ElevatedButton.icon(
+                                  onPressed: () => _sendFriendRequest(user.id),
+                                  icon: const Icon(Icons.person_add, size: 18),
+                                  label: const Text('요청'),
+                                ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/social/presentation/widgets/friends_list_tab.dart
+++ b/lib/features/social/presentation/widgets/friends_list_tab.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_state.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_event.dart';
+import 'package:co_workfit/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:co_workfit/features/auth/presentation/bloc/auth_state.dart';
+
+class FriendsListTab extends StatelessWidget {
+  const FriendsListTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SocialBloc, SocialState>(
+      builder: (context, state) {
+        if (state is SocialLoading) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (state is SocialError && state.previousState == null) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text('오류: ${state.message}'),
+                const SizedBox(height: 16),
+                ElevatedButton(
+                  onPressed: () {
+                    final authState = context.read<AuthBloc>().state;
+                    if (authState is Authenticated) {
+                      context.read<SocialBloc>().add(LoadFriends(authState.user.id));
+                    }
+                  },
+                  child: const Text('다시 시도'),
+                ),
+              ],
+            ),
+          );
+        }
+
+        final friends = state is SocialLoaded
+            ? state.friends
+            : state is SocialActionSuccess
+                ? state.newState.friends
+                : state is SocialActionInProgress
+                    ? state.currentState.friends
+                    : state is SocialError && state.previousState != null
+                        ? state.previousState!.friends
+                        : <dynamic>[];
+
+        if (friends.isEmpty) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Icon(Icons.people_outline, size: 64, color: Colors.grey),
+                const SizedBox(height: 16),
+                const Text(
+                  '아직 친구가 없습니다',
+                  style: TextStyle(fontSize: 18, color: Colors.grey),
+                ),
+                const SizedBox(height: 8),
+                const Text(
+                  '친구 추가 탭에서 친구를 추가해보세요!',
+                  style: TextStyle(color: Colors.grey),
+                ),
+              ],
+            ),
+          );
+        }
+
+        return RefreshIndicator(
+          onRefresh: () async {
+            final authState = context.read<AuthBloc>().state;
+            if (authState is Authenticated) {
+              context.read<SocialBloc>().add(RefreshFriends(authState.user.id));
+            }
+          },
+          child: ListView.builder(
+            itemCount: friends.length,
+            itemBuilder: (context, index) {
+              final friend = friends[index];
+              return Card(
+                margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: ListTile(
+                  leading: CircleAvatar(
+                    backgroundImage: friend.friendPhotoUrl != null
+                        ? NetworkImage(friend.friendPhotoUrl!)
+                        : null,
+                    child: friend.friendPhotoUrl == null
+                        ? Text(friend.friendName[0].toUpperCase())
+                        : null,
+                  ),
+                  title: Text(friend.friendName),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(friend.friendEmail),
+                      const SizedBox(height: 4),
+                      Text(
+                        '점수: ${friend.friendTotalScore} | 운동: ${friend.friendWorkoutCount}회',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Colors.grey[600],
+                        ),
+                      ),
+                    ],
+                  ),
+                  isThreeLine: true,
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/social/presentation/widgets/received_requests_tab.dart
+++ b/lib/features/social/presentation/widgets/received_requests_tab.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_state.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_event.dart';
+
+class ReceivedRequestsTab extends StatelessWidget {
+  const ReceivedRequestsTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SocialBloc, SocialState>(
+      builder: (context, state) {
+        if (state is SocialLoading) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final requests = state is SocialLoaded
+            ? state.receivedRequests
+            : state is SocialActionSuccess
+                ? state.newState.receivedRequests
+                : state is SocialActionInProgress
+                    ? state.currentState.receivedRequests
+                    : state is SocialError && state.previousState != null
+                        ? state.previousState!.receivedRequests
+                        : <dynamic>[];
+
+        if (requests.isEmpty) {
+          return const Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.inbox_outlined, size: 64, color: Colors.grey),
+                SizedBox(height: 16),
+                Text(
+                  '받은 친구 요청이 없습니다',
+                  style: TextStyle(fontSize: 18, color: Colors.grey),
+                ),
+              ],
+            ),
+          );
+        }
+
+        return ListView.builder(
+          itemCount: requests.length,
+          itemBuilder: (context, index) {
+            final request = requests[index];
+            return Card(
+              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: ListTile(
+                leading: CircleAvatar(
+                  backgroundImage: request.senderPhotoUrl != null
+                      ? NetworkImage(request.senderPhotoUrl!)
+                      : null,
+                  child: request.senderPhotoUrl == null
+                      ? Text(request.senderName[0].toUpperCase())
+                      : null,
+                ),
+                title: Text(request.senderName),
+                subtitle: Text(
+                  '${_formatDate(request.createdAt)}에 요청',
+                  style: const TextStyle(fontSize: 12),
+                ),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.check, color: Colors.green),
+                      onPressed: () {
+                        context.read<SocialBloc>().add(
+                          AcceptFriendRequestEvent(request.id),
+                        );
+                      },
+                      tooltip: '수락',
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close, color: Colors.red),
+                      onPressed: () {
+                        context.read<SocialBloc>().add(
+                          RejectFriendRequestEvent(request.id),
+                        );
+                      },
+                      tooltip: '거절',
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    final now = DateTime.now();
+    final difference = now.difference(date);
+
+    if (difference.inDays > 7) {
+      return '${date.year}.${date.month}.${date.day}';
+    } else if (difference.inDays > 0) {
+      return '${difference.inDays}일 전';
+    } else if (difference.inHours > 0) {
+      return '${difference.inHours}시간 전';
+    } else if (difference.inMinutes > 0) {
+      return '${difference.inMinutes}분 전';
+    } else {
+      return '방금';
+    }
+  }
+}

--- a/lib/features/social/presentation/widgets/sent_requests_tab.dart
+++ b/lib/features/social/presentation/widgets/sent_requests_tab.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_state.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_event.dart';
+
+class SentRequestsTab extends StatelessWidget {
+  const SentRequestsTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SocialBloc, SocialState>(
+      builder: (context, state) {
+        if (state is SocialLoading) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        final requests = state is SocialLoaded
+            ? state.sentRequests
+            : state is SocialActionSuccess
+                ? state.newState.sentRequests
+                : state is SocialActionInProgress
+                    ? state.currentState.sentRequests
+                    : state is SocialError && state.previousState != null
+                        ? state.previousState!.sentRequests
+                        : <dynamic>[];
+
+        if (requests.isEmpty) {
+          return const Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.send_outlined, size: 64, color: Colors.grey),
+                SizedBox(height: 16),
+                Text(
+                  '보낸 친구 요청이 없습니다',
+                  style: TextStyle(fontSize: 18, color: Colors.grey),
+                ),
+              ],
+            ),
+          );
+        }
+
+        return ListView.builder(
+          itemCount: requests.length,
+          itemBuilder: (context, index) {
+            final request = requests[index];
+            return Card(
+              margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: ListTile(
+                leading: const CircleAvatar(
+                  child: Icon(Icons.person_outline),
+                ),
+                title: Text('사용자 ${request.receiverId.substring(0, 8)}...'),
+                subtitle: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '${_formatDate(request.createdAt)}에 전송',
+                      style: const TextStyle(fontSize: 12),
+                    ),
+                    const SizedBox(height: 4),
+                    Chip(
+                      label: Text(
+                        _getStatusText(request.status.name),
+                        style: const TextStyle(fontSize: 11),
+                      ),
+                      backgroundColor: _getStatusColor(request.status.name),
+                      padding: EdgeInsets.zero,
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  ],
+                ),
+                isThreeLine: true,
+                trailing: request.status.name == 'pending'
+                    ? IconButton(
+                        icon: const Icon(Icons.cancel_outlined, color: Colors.red),
+                        onPressed: () {
+                          context.read<SocialBloc>().add(
+                            CancelFriendRequestEvent(request.id),
+                          );
+                        },
+                        tooltip: '취소',
+                      )
+                    : null,
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    final now = DateTime.now();
+    final difference = now.difference(date);
+
+    if (difference.inDays > 7) {
+      return '${date.year}.${date.month}.${date.day}';
+    } else if (difference.inDays > 0) {
+      return '${difference.inDays}일 전';
+    } else if (difference.inHours > 0) {
+      return '${difference.inHours}시간 전';
+    } else if (difference.inMinutes > 0) {
+      return '${difference.inMinutes}분 전';
+    } else {
+      return '방금';
+    }
+  }
+
+  String _getStatusText(String status) {
+    switch (status) {
+      case 'pending':
+        return '대기 중';
+      case 'accepted':
+        return '수락됨';
+      case 'rejected':
+        return '거절됨';
+      default:
+        return status;
+    }
+  }
+
+  Color _getStatusColor(String status) {
+    switch (status) {
+      case 'pending':
+        return Colors.orange.shade100;
+      case 'accepted':
+        return Colors.green.shade100;
+      case 'rejected':
+        return Colors.red.shade100;
+      default:
+        return Colors.grey.shade100;
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:co_workfit/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:co_workfit/features/auth/presentation/bloc/auth_event.dart';
 import 'package:co_workfit/features/profile/presentation/bloc/profile_bloc.dart';
 import 'package:co_workfit/features/auth/presentation/bloc/auth_state.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_bloc.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -47,6 +48,9 @@ class CoWorkFitApp extends StatelessWidget {
         ),
         BlocProvider<ProfileBloc>(
           create: (_) => di.sl<ProfileBloc>(),
+        ),
+        BlocProvider<SocialBloc>(
+          create: (_) => di.sl<SocialBloc>(),
         ),
       ],
       child: MaterialApp(


### PR DESCRIPTION
## 관련 이슈
Closes #5

## 개요
친구 시스템 백엔드와 연동되는 친구 관리 UI를 구현했습니다.

## 주요 변경사항

### 🏗️ Architecture
- **Domain Layer**: Repository 인터페이스 및 8개 Use Cases 구현
- **Data Layer**: Repository 구현체 및 데이터 매핑 로직
- **Presentation Layer**: BLoC 패턴 기반 상태 관리 및 UI 컴포넌트

### ✨ 구현된 기능

#### 1. 친구 목록 탭
- ✅ 현재 친구 목록 표시
- ✅ 친구별 정보 (이름, 이메일, 점수, 운동 횟수)
- ✅ Pull-to-refresh 기능

#### 2. 친구 추가 탭
- ✅ 이메일로 사용자 검색
- ✅ 검색 결과 표시
- ✅ 친구 요청 보내기 버튼

#### 3. 받은 친구 요청 탭
- ✅ 받은 요청 목록
- ✅ 수락/거절 버튼
- ✅ 요청 시간 표시

#### 4. 보낸 친구 요청 탭
- ✅ 보낸 요청 목록
- ✅ 취소 버튼
- ✅ 요청 상태 표시 (대기중/수락됨/거절됨)

### 📋 BLoC 연동
- ✅ SocialBloc 생성
- ✅ 친구 관련 Event/State 정의
- ✅ Use Cases 호출 완료

### 🎨 UX Features
- 실시간 액션 피드백 (SnackBar)
- 자동 데이터 새로고침
- 에러 처리 및 로딩 상태 표시
- 한글 UI

## 파일 구조
```
lib/features/social/
├── domain/
│   ├── repositories/social_repository.dart
│   └── usecases/
│       ├── get_friends.dart
│       ├── send_friend_request.dart
│       ├── get_received_friend_requests.dart
│       ├── get_sent_friend_requests.dart
│       ├── accept_friend_request.dart
│       ├── reject_friend_request.dart
│       ├── cancel_friend_request.dart
│       └── search_users_by_email.dart
├── data/
│   └── repositories/social_repository_impl.dart
└── presentation/
    ├── bloc/
    │   ├── social_bloc.dart
    │   ├── social_event.dart
    │   └── social_state.dart
    ├── pages/friends_page.dart
    └── widgets/
        ├── friends_list_tab.dart
        ├── add_friend_tab.dart
        ├── received_requests_tab.dart
        └── sent_requests_tab.dart
```

## 테스트 계획
- [ ] 친구 목록 조회 테스트
- [ ] 친구 요청 보내기 테스트
- [ ] 친구 요청 수락/거절 테스트
- [ ] 친구 요청 취소 테스트
- [ ] 사용자 검색 테스트

## 스크린샷
<!-- 추후 추가 예정 -->

## 기술 스택
- Flutter BLoC 패턴
- Clean Architecture
- Firebase/Firestore 연동
- Dependency Injection (get_it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)