### PR TITLE
fix: Android Google Sign-In OAuth 설정 추가 및 개발 환경 구성

### DIFF
--- a/.claud
+++ b/.claud
@@ -76,6 +76,32 @@ lib/
 
 ---
 
+## 🔧 개발 환경 설정
+
+### Android 개발 환경
+
+Android 관련 작업(SHA-1 확인, Gradle 빌드, 서명 등)을 수행하기 전에 **반드시** 환경 설정이 필요합니다:
+
+```bash
+# 환경 변수 설정 (매번 새 터미널 세션마다 실행)
+source scripts/setup-env.sh
+```
+
+이 스크립트는:
+- Java 경로를 자동 설정 (`JAVA_HOME`)
+- Android 개발 도구 경로를 PATH에 추가
+- 설정 완료 여부를 확인 및 출력
+
+**워크트리를 사용하는 경우 필수!**
+- 매번 새 워크트리가 생성될 때마다 환경변수가 초기화됨
+- `source scripts/setup-env.sh` 실행 없이 `keytool`, `./gradlew` 등 실행 시 에러 발생
+
+**관련 파일:**
+- `scripts/setup-env.sh` - 환경 설정 스크립트
+- `.envrc` - 환경 변수 정의 (git ignored)
+
+---
+
 ## 🎯 핵심 원칙
 
 ### 1. 문서를 먼저 확인하라

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Environment variables
+.envrc

--- a/GOOGLE_SIGNIN_FIX.md
+++ b/GOOGLE_SIGNIN_FIX.md
@@ -1,0 +1,137 @@
+# Android Google Sign-In 수정 가이드
+
+## 문제 상황
+안드로이드에서 구글 로그인 시도 후 앱으로 복귀하면 로그인이 완료되지 않는 이슈
+
+## 원인
+`android/app/google-services.json`에 OAuth 클라이언트 설정이 누락됨
+
+## 해결 방법
+
+### 1단계: SHA-1 인증서 지문 확인
+
+#### Debug용 SHA-1 (개발/테스트)
+```bash
+cd android
+./gradlew signingReport
+```
+
+또는:
+```bash
+keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android
+```
+
+#### Release용 SHA-1 (프로덕션)
+```bash
+keytool -list -v -keystore /path/to/your/release.keystore -alias your-alias
+```
+
+SHA-1 지문을 복사해두세요. 예시:
+```
+SHA1: 12:34:56:78:90:AB:CD:EF:12:34:56:78:90:AB:CD:EF:12:34:56:78
+```
+
+### 2단계: Firebase Console에서 SHA-1 등록
+
+1. [Firebase Console](https://console.firebase.google.com/) 접속
+2. **co-workfit** 프로젝트 선택
+3. 좌측 메뉴에서 **프로젝트 설정** (⚙️) 클릭
+4. **일반** 탭 선택
+5. **내 앱** 섹션에서 Android 앱 찾기
+6. **SHA 인증서 지문** 섹션에서 **지문 추가** 클릭
+7. Debug SHA-1과 Release SHA-1 둘 다 추가
+
+### 3단계: OAuth 2.0 클라이언트 ID 생성
+
+Firebase Console에서 SHA-1을 추가하면 자동으로 OAuth 클라이언트가 생성됩니다.
+
+또는 수동으로:
+
+1. [Google Cloud Console](https://console.cloud.google.com/) 접속
+2. **co-workfit** 프로젝트 선택
+3. **APIs & Services** > **사용자 인증 정보** 메뉴
+4. **+ 사용자 인증 정보 만들기** > **OAuth 클라이언트 ID** 클릭
+5. 애플리케이션 유형: **Android** 선택
+6. 이름: `Co-WorkFit Android`
+7. 패키지 이름: `com.coworkfit.co_workfit`
+8. SHA-1 인증서 지문 입력
+9. **만들기** 클릭
+
+### 4단계: google-services.json 다운로드 및 교체
+
+1. Firebase Console > 프로젝트 설정 > 일반
+2. **내 앱** 섹션에서 Android 앱 선택
+3. **google-services.json 다운로드** 클릭
+4. 다운로드한 파일을 `android/app/google-services.json`에 덮어쓰기
+
+새 파일에는 `oauth_client` 배열이 채워져 있어야 합니다:
+```json
+"oauth_client": [
+  {
+    "client_id": "89240730998-xxxxxxxxxxxxx.apps.googleusercontent.com",
+    "client_type": 3
+  }
+]
+```
+
+### 5단계: 빌드 후 테스트
+
+```bash
+# 클린 빌드
+flutter clean
+flutter pub get
+
+# 안드로이드 빌드 및 실행
+flutter run
+```
+
+## 추가 확인 사항
+
+### Google Sign-In 플러그인 버전 확인
+`pubspec.yaml`에서:
+```yaml
+dependencies:
+  google_sign_in: ^6.2.2  # ✅ 최신 버전 사용 중
+```
+
+### AndroidManifest.xml 확인
+특별한 설정 불필요 - Google Sign-In 플러그인이 자동으로 처리
+
+### 디버깅 로그 추가 (선택사항)
+문제가 계속되면 로그를 추가하여 원인 파악:
+
+`lib/features/auth/data/datasources/firebase_auth_datasource.dart`의 `signInWithGoogle()` 메서드에:
+
+```dart
+try {
+  AppLogger.info('GoogleSignIn', 'Starting Google sign-in flow');
+  final GoogleSignInAccount? googleUser = await _googleSignIn.signIn();
+
+  if (googleUser == null) {
+    AppLogger.warning('GoogleSignIn', 'User cancelled sign-in');
+    return const Left('Google 로그인이 취소되었습니다.');
+  }
+
+  AppLogger.info('GoogleSignIn', 'Google user signed in: ${googleUser.email}');
+  // ... 나머지 코드
+} catch (e) {
+  AppLogger.error('GoogleSignIn', 'Sign-in failed: $e');
+  return Left('Google 로그인에 실패했습니다: $e');
+}
+```
+
+## 체크리스트
+
+- [ ] SHA-1 지문 확인 (Debug & Release)
+- [ ] Firebase Console에 SHA-1 등록
+- [ ] OAuth 2.0 클라이언트 ID 생성 확인
+- [ ] 새 google-services.json 다운로드 및 교체
+- [ ] oauth_client 배열이 비어있지 않은지 확인
+- [ ] Clean build 및 재실행
+- [ ] 안드로이드 기기에서 Google 로그인 테스트
+
+## 참고 자료
+
+- [Firebase Android 설정](https://firebase.google.com/docs/android/setup)
+- [Google Sign-In for Android](https://developers.google.com/identity/sign-in/android/start)
+- [Flutter google_sign_in 플러그인](https://pub.dev/packages/google_sign_in)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,17 @@ flutterfire configure
 flutter run
 ```
 
+### Android 개발 환경 설정
+
+Android 관련 작업(SHA-1 확인, Gradle 빌드 등)을 수행하기 전에 환경 설정이 필요합니다:
+
+```bash
+# 환경 변수 설정 (매번 새 터미널 세션마다 실행)
+source scripts/setup-env.sh
+```
+
+이 스크립트는 자동으로 Java 경로를 설정하고 Android 개발 도구를 사용할 수 있게 합니다.
+
 ### 개발
 
 ```bash

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -12,7 +12,20 @@
           "package_name": "com.coworkfit.co_workfit"
         }
       },
-      "oauth_client": [],
+      "oauth_client": [
+        {
+          "client_id": "89240730998-lvh2bmj6ha6pmtk8h416jocam5i1qf1a.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.coworkfit.co_workfit",
+            "certificate_hash": "b17a41ae7485b52f9e8006f6ec12bda2efff221e"
+          }
+        },
+        {
+          "client_id": "89240730998-ckcr8c3dlubeckelcncmn0hsnc0bift7.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
       "api_key": [
         {
           "current_key": "AIzaSyD8qTv8_Y4lVwY0_u6lTWb_c1IJ2WL4yIM"
@@ -20,7 +33,19 @@
       ],
       "services": {
         "appinvite_service": {
-          "other_platform_oauth_client": []
+          "other_platform_oauth_client": [
+            {
+              "client_id": "89240730998-ckcr8c3dlubeckelcncmn0hsnc0bift7.apps.googleusercontent.com",
+              "client_type": 3
+            },
+            {
+              "client_id": "89240730998-618nn4aqpg6il1vt0prphp0o40iqogob.apps.googleusercontent.com",
+              "client_type": 2,
+              "ios_info": {
+                "bundle_id": "com.hansol.coworkfit"
+              }
+            }
+          ]
         }
       }
     }

--- a/scripts/setup-env.sh
+++ b/scripts/setup-env.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Setup script for Android development environment
+# Source this file before running Android-related commands: source scripts/setup-env.sh
+
+echo "Setting up Android development environment..."
+
+# Java setup
+export JAVA_HOME=/opt/homebrew/opt/openjdk@17
+export PATH=$JAVA_HOME/bin:$PATH
+
+# Verify Java installation
+if [ -x "$JAVA_HOME/bin/java" ]; then
+    echo "✅ Java found: $($JAVA_HOME/bin/java --version | head -n 1)"
+else
+    echo "❌ Java not found at $JAVA_HOME"
+    echo "Please install Java: brew install openjdk@17"
+    return 1
+fi
+
+# Android SDK (optional - uncomment if needed)
+# if [ -d "$HOME/Library/Android/sdk" ]; then
+#     export ANDROID_HOME=$HOME/Library/Android/sdk
+#     export PATH=$PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools
+#     echo "✅ Android SDK found"
+# fi
+
+echo "✅ Environment setup complete!"
+echo ""
+echo "You can now run Android development commands:"
+echo "  - keytool (for SHA-1 fingerprints)"
+echo "  - ./gradlew (for Gradle tasks)"


### PR DESCRIPTION
## 개요
안드로이드에서 구글 로그인 후 앱으로 복귀 시 로그인이 완료되지 않는 이슈를 해결합니다.

## 주요 변경사항

### 1. Google Sign-In OAuth 클라이언트 설정 수정
- **문제**: `android/app/google-services.json`의 `oauth_client` 배열이 비어있음
- **해결**: Firebase Console에 SHA-1 지문 등록 후 OAuth 클라이언트 추가
  - Android OAuth Client (client_type: 1)
  - Web OAuth Client (client_type: 3)
  - iOS OAuth Client 정보 포함

### 2. 개발 환경 설정 자동화
- `scripts/setup-env.sh`: Java 환경변수 자동 설정 스크립트
- `.envrc`: 프로젝트별 환경변수 정의 (git ignored)
- 워크트리 환경에서도 Java/Android 개발 도구 사용 가능

### 3. 문서화
- `GOOGLE_SIGNIN_FIX.md`: Android Google Sign-In 수정 상세 가이드
- `README.md`: Android 개발 환경 설정 섹션 추가
- `.claud`: 개발 환경 설정 규칙 추가

## 변경된 파일
- `android/app/google-services.json` - OAuth 클라이언트 추가
- `scripts/setup-env.sh` - 환경 설정 스크립트 (신규)
- `.envrc` - 환경 변수 정의 (신규)
- `GOOGLE_SIGNIN_FIX.md` - 수정 가이드 (신규)
- `README.md` - Android 개발 환경 설정 추가
- `.claud` - 개발 규칙 업데이트
- `.gitignore` - .envrc 추가

## 테스트 방법
```bash
# 환경 설정
source scripts/setup-env.sh

# SHA-1 확인
keytool -list -v -keystore ~/.android/debug.keystore -alias androiddebugkey -storepass android -keypass android

# 빌드 및 테스트
flutter clean
flutter pub get
flutter run
```

안드로이드 기기에서 구글 로그인 테스트 필요

## 해결된 이슈
- Closes #37

## 체크리스트
- [x] SHA-1 지문 Firebase Console 등록
- [x] google-services.json OAuth 클라이언트 확인
- [x] 환경 설정 스크립트 작성
- [x] 문서 업데이트
- [ ] 안드로이드 기기에서 실제 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)