### PR TITLE
feat: 고정 Keystore를 사용한 릴리즈 APK 서명 설정

### DIFF
--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -59,6 +59,14 @@ jobs:
       - name: Get dependencies
         run: flutter pub get
 
+      - name: Setup release keystore
+        run: |
+          echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | base64 --decode > android/app/release-keystore.jks
+          echo "storeFile=release-keystore.jks" > android/key.properties
+          echo "storePassword=${{ secrets.RELEASE_KEYSTORE_PASSWORD }}" >> android/key.properties
+          echo "keyAlias=${{ secrets.RELEASE_KEY_ALIAS }}" >> android/key.properties
+          echo "keyPassword=${{ secrets.RELEASE_KEY_PASSWORD }}" >> android/key.properties
+
       - name: Run tests (optional)
         run: flutter test || echo "No tests or tests failed - continuing anyway"
 

--- a/.github/workflows/deploy-apk.yml
+++ b/.github/workflows/deploy-apk.yml
@@ -130,6 +130,21 @@ jobs:
           echo "file_size=$FILE_SIZE" >> $GITHUB_OUTPUT
           echo "APK built: $APK_PATH ($FILE_SIZE)"
 
+      - name: Print APK signing SHA-1 (for Firebase)
+        run: |
+          echo "=========================================="
+          echo "🔑 APK Signing Certificate SHA-1"
+          echo "=========================================="
+          # apksigner로 SHA-1 추출
+          APK_PATH="build/app/outputs/flutter-apk/app-release.apk"
+          CERT_INFO=$($ANDROID_HOME/build-tools/$(ls $ANDROID_HOME/build-tools | tail -1)/apksigner verify --print-certs "$APK_PATH" 2>&1)
+          echo "$CERT_INFO"
+          echo ""
+          echo "=========================================="
+          echo "⚠️  위의 SHA-1 fingerprint를 Firebase Console에 등록하세요!"
+          echo "    Firebase Console → Project Settings → Android app → Add fingerprint"
+          echo "=========================================="
+
       - name: Rename APK with version
         id: rename_apk
         run: |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import java.io.FileInputStream
+
 plugins {
     id("com.android.application")
     // START: FlutterFire Configuration
@@ -6,6 +9,12 @@ plugins {
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+val keystorePropertiesFile = rootProject.file("key.properties")
+val keystoreProperties = Properties()
+if (keystorePropertiesFile.exists()) {
+    keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
 android {
@@ -33,11 +42,24 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            if (keystorePropertiesFile.exists()) {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = file(keystoreProperties["storeFile"] as String)
+                storePassword = keystoreProperties["storePassword"] as String
+            }
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (keystorePropertiesFile.exists()) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.1+3
+version: 0.0.1+4
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
## Summary
- GitHub Actions에서 고정 Keystore를 사용하여 릴리즈 APK 서명
- 매 빌드마다 동일한 SHA-1 유지로 구글 로그인 문제 해결
- key.properties 기반 서명 설정 추가 (없으면 debug 키로 폴백)

## 필요한 GitHub Secrets
- `RELEASE_KEYSTORE_BASE64`
- `RELEASE_KEYSTORE_PASSWORD`
- `RELEASE_KEY_ALIAS`
- `RELEASE_KEY_PASSWORD`

## Test plan
- [ ] GitHub Actions 빌드 후 SHA-1 확인
- [ ] Firebase App Distribution 배포 후 구글 로그인 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)