### PR TITLE
fix: Android 러닝 거리 계산 오류 수정 및 코드 리팩토링

### DIFF
--- a/lib/features/workout/data/datasources/google_fit_datasource.dart
+++ b/lib/features/workout/data/datasources/google_fit_datasource.dart
@@ -2,13 +2,17 @@ import 'package:health/health.dart';
 import 'package:co_workfit/core/constants/health_data_types.dart';
 import 'package:dartz/dartz.dart';
 import 'package:co_workfit/core/utils/logger.dart';
+import 'workout_details_fetcher.dart';
 
 /// Google Fit 데이터 소스
 /// Android 기기에서 Google Fit 데이터를 가져옵니다.
 class GoogleFitDataSource {
   final Health _health;
+  final WorkoutDetailsFetcher _detailsFetcher;
 
-  GoogleFitDataSource({Health? health}) : _health = health ?? Health();
+  GoogleFitDataSource({Health? health})
+      : _health = health ?? Health(),
+        _detailsFetcher = WorkoutDetailsFetcher(health: health);
 
   /// Google Fit 권한 요청
   /// Returns: Right(true) if authorized, Left(error) if failed
@@ -91,6 +95,11 @@ class GoogleFitDataSource {
   }
 
   /// 특정 운동에 대한 상세 데이터 가져오기 (칼로리, 거리, 심박수 등)
+  ///
+  /// 거리 데이터는 WORKOUT의 totalDistance를 사용
+  /// DISTANCE_DELTA는 사용하지 않음 (중복 데이터, 부정확한 시간 범위 문제)
+  /// 참고: https://developers.google.com/fit/datatypes
+  ///
   /// [workoutStart]: 운동 시작 시간
   /// [workoutEnd]: 운동 종료 시간
   /// Returns: 운동 상세 데이터 Map
@@ -98,110 +107,10 @@ class GoogleFitDataSource {
     required DateTime workoutStart,
     required DateTime workoutEnd,
   }) async {
-    try {
-      final details = <String, dynamic>{};
-
-      // 칼로리 데이터 (Google Fit은 ACTIVE_ENERGY_BURNED 또는 TOTAL_CALORIES_BURNED)
-      final caloriesData = await _health.getHealthDataFromTypes(
-        types: [
-          HealthDataType.ACTIVE_ENERGY_BURNED,
-        ],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (caloriesData.isNotEmpty) {
-        final totalCalories = caloriesData.fold<double>(
-          0,
-          (sum, point) =>
-              sum + (point.value as NumericHealthValue).numericValue,
-        );
-        details['calories'] = totalCalories.round();
-      }
-
-      // 거리 데이터
-      final distanceData = await _health.getHealthDataFromTypes(
-        types: [
-          HealthDataType.DISTANCE_DELTA,
-        ],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (distanceData.isNotEmpty) {
-        final totalDistance = distanceData.fold<double>(
-          0,
-          (sum, point) =>
-              sum + (point.value as NumericHealthValue).numericValue,
-        );
-        // meters to kilometers
-        details['distance'] = totalDistance / 1000.0;
-      }
-
-      // 걸음 수
-      final stepsData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.STEPS],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (stepsData.isNotEmpty) {
-        final totalSteps = stepsData.fold<double>(
-          0,
-          (sum, point) =>
-              sum + (point.value as NumericHealthValue).numericValue,
-        );
-        details['steps'] = totalSteps.round();
-      }
-
-      // 심박수 데이터
-      final heartRateData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.HEART_RATE],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (heartRateData.isNotEmpty) {
-        final heartRates = heartRateData
-            .map((point) => (point.value as NumericHealthValue).numericValue)
-            .toList();
-
-        if (heartRates.isNotEmpty) {
-          final avgHeartRate =
-              heartRates.reduce((a, b) => a + b) / heartRates.length;
-          final maxHeartRate = heartRates.reduce((a, b) => a > b ? a : b);
-
-          details['averageHeartRate'] = avgHeartRate.round();
-          details['maxHeartRate'] = maxHeartRate.round();
-        }
-      }
-
-      // 고도 상승 (Google Fit에서 지원하는 경우)
-      try {
-        final elevationData = await _health.getHealthDataFromTypes(
-          types: [HealthDataType.FLIGHTS_CLIMBED],
-          startTime: workoutStart,
-          endTime: workoutEnd,
-        );
-
-        if (elevationData.isNotEmpty) {
-          final totalFlights = elevationData.fold<double>(
-            0,
-            (sum, point) =>
-                sum + (point.value as NumericHealthValue).numericValue,
-          );
-          // 1 flight ≈ 3 meters
-          details['elevationGain'] = totalFlights * 3.0;
-        }
-      } catch (e) {
-        // FLIGHTS_CLIMBED가 지원되지 않을 수 있음
-        AppLogger.debug('GoogleFit', '고도 데이터 가져오기 실패 (지원되지 않을 수 있음): $e');
-      }
-
-      return Right(details);
-    } catch (e) {
-      return Left('운동 상세 데이터 가져오기 실패: ${e.toString()}');
-    }
+    return _detailsFetcher.fetchWorkoutDetails(
+      workoutStart: workoutStart,
+      workoutEnd: workoutEnd,
+    );
   }
 
   /// Google Fit 사용 가능 여부 확인

--- a/lib/features/workout/data/datasources/health_connect_datasource.dart
+++ b/lib/features/workout/data/datasources/health_connect_datasource.dart
@@ -5,13 +5,17 @@ import 'package:co_workfit/core/platform/health_connect_checker.dart';
 import 'package:dartz/dartz.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:co_workfit/core/utils/logger.dart';
+import 'workout_details_fetcher.dart';
 
 /// Health Connect 데이터 소스
 /// Android에서 Health Connect를 통해 여러 소스(Google Fit, Samsung Health 등)의 데이터를 통합 관리합니다.
 class HealthConnectDataSource {
   final Health _health;
+  final WorkoutDetailsFetcher _detailsFetcher;
 
-  HealthConnectDataSource({Health? health}) : _health = health ?? Health();
+  HealthConnectDataSource({Health? health})
+      : _health = health ?? Health(),
+        _detailsFetcher = WorkoutDetailsFetcher(health: health);
 
   /// Health Connect 권한 요청
   ///
@@ -157,6 +161,17 @@ class HealthConnectDataSource {
       // 소스 정보를 포함한 데이터로 변환
       final dataWithSource = healthData.map((point) {
         final source = _detectWorkoutSource(point);
+
+        // WORKOUT 데이터의 totalDistance 정보 로깅
+        if (point.value is WorkoutHealthValue) {
+          final workoutValue = point.value as WorkoutHealthValue;
+          AppLogger.debug('HealthConnect',
+            'WORKOUT 데이터: type=${workoutValue.workoutActivityType}, '
+            'totalDistance=${workoutValue.totalDistance}, '
+            'unit=${workoutValue.totalDistanceUnit}, '
+            'source=${point.sourceName}');
+        }
+
         return HealthDataPointWithSource(
           healthDataPoint: point,
           detectedSource: source,
@@ -212,103 +227,25 @@ class HealthConnectDataSource {
   }
 
   /// 특정 운동에 대한 상세 데이터 가져오기
+  ///
   /// 거리 데이터는 WORKOUT의 totalDistance를 직접 사용하므로 여기서는 조회하지 않음
+  ///
+  /// 참고: https://developer.android.com/health-and-fitness/guides/health-connect/plan/data-types
+  ///
+  /// DISTANCE_DELTA(DistanceRecord)는 독립적인 거리 측정 포인트들로,
+  /// 여러 앱에서 중복 기록되거나 운동 전후 이동이 포함될 수 있어 부정확함.
+  /// WORKOUT(ExerciseSessionRecord)의 totalDistance가 정확한 운동 거리임.
+  ///
+  /// 주의: totalDistance가 null인 경우 위치 권한이 필요할 수 있음
+  /// (ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION)
   Future<Either<String, Map<String, dynamic>>> fetchWorkoutDetails({
     required DateTime workoutStart,
     required DateTime workoutEnd,
   }) async {
-    try {
-      final details = <String, dynamic>{};
-
-      // 칼로리
-      final caloriesData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.ACTIVE_ENERGY_BURNED],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (caloriesData.isNotEmpty) {
-        final totalCalories = caloriesData.fold<double>(
-          0,
-          (sum, point) => sum + (point.value as NumericHealthValue).numericValue,
-        );
-        details['calories'] = totalCalories.round();
-      }
-
-      // 거리
-      final distanceData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.DISTANCE_DELTA],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (distanceData.isNotEmpty) {
-        final totalDistance = distanceData.fold<double>(
-          0,
-          (sum, point) => sum + (point.value as NumericHealthValue).numericValue,
-        );
-        details['distance'] = totalDistance / 1000.0;
-      }
-
-      // 걸음 수
-      final stepsData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.STEPS],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (stepsData.isNotEmpty) {
-        final totalSteps = stepsData.fold<double>(
-          0,
-          (sum, point) => sum + (point.value as NumericHealthValue).numericValue,
-        );
-        details['steps'] = totalSteps.round();
-      }
-
-      // 심박수
-      final heartRateData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.HEART_RATE],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (heartRateData.isNotEmpty) {
-        final heartRates = heartRateData
-            .map((point) => (point.value as NumericHealthValue).numericValue)
-            .toList();
-
-        if (heartRates.isNotEmpty) {
-          final avgHeartRate = heartRates.reduce((a, b) => a + b) / heartRates.length;
-          final maxHeartRate = heartRates.reduce((a, b) => a > b ? a : b);
-
-          details['averageHeartRate'] = avgHeartRate.round();
-          details['maxHeartRate'] = maxHeartRate.round();
-        }
-      }
-
-      // 고도
-      try {
-        final elevationData = await _health.getHealthDataFromTypes(
-          types: [HealthDataType.FLIGHTS_CLIMBED],
-          startTime: workoutStart,
-          endTime: workoutEnd,
-        );
-
-        if (elevationData.isNotEmpty) {
-          final totalFlights = elevationData.fold<double>(
-            0,
-            (sum, point) => sum + (point.value as NumericHealthValue).numericValue,
-          );
-          details['elevationGain'] = totalFlights * 3.0;
-        }
-      } catch (e) {
-        // 지원되지 않을 수 있음
-      }
-
-      return Right(details);
-    } catch (e) {
-      return Left('운동 상세 데이터 가져오기 실패: ${e.toString()}');
-    }
+    return _detailsFetcher.fetchWorkoutDetails(
+      workoutStart: workoutStart,
+      workoutEnd: workoutEnd,
+    );
   }
 
   /// Health Connect 사용 가능 여부 확인

--- a/lib/features/workout/data/datasources/health_data_mapper.dart
+++ b/lib/features/workout/data/datasources/health_data_mapper.dart
@@ -44,14 +44,26 @@ class HealthDataMapper {
       // 단위에 따라 킬로미터로 변환
       if (unit == HealthDataUnit.METER) {
         distance = rawDistance / 1000.0;
-        AppLogger.debug('HealthDataMapper', 'WORKOUT 거리: ${rawDistance}m → ${distance}km');
+        AppLogger.debug('HealthDataMapper', 'WORKOUT 거리: ${rawDistance}m → $distance km');
       } else if (unit == HealthDataUnit.MILE) {
         distance = rawDistance * 1.60934;
-        AppLogger.debug('HealthDataMapper', 'WORKOUT 거리: ${rawDistance}mi → ${distance}km');
+        AppLogger.debug('HealthDataMapper', 'WORKOUT 거리: ${rawDistance}mi → $distance km');
       } else {
         // 알 수 없는 단위는 미터로 가정
         distance = rawDistance / 1000.0;
-        AppLogger.debug('HealthDataMapper', 'WORKOUT 거리 (알 수 없는 단위 $unit): ${rawDistance} → ${distance}km');
+        AppLogger.debug('HealthDataMapper', 'WORKOUT 거리 (알 수 없는 단위 $unit): $rawDistance → $distance km');
+      }
+    } else {
+      // WORKOUT에 totalDistance가 없는 경우
+      AppLogger.warning('HealthDataMapper',
+        'WORKOUT totalDistance null - 위치 권한 필요 가능성 있음 '
+        '(source: $source, type: $workoutType, '
+        'start: $startTime, end: $endTime)');
+
+      // fallback: details에서 가져옴 (하위 호환성)
+      if (details.containsKey('distance') && details['distance'] != null) {
+        distance = details['distance'] as double?;
+        AppLogger.info('HealthDataMapper', 'fallback distance 사용: $distance km');
       }
     }
 

--- a/lib/features/workout/data/datasources/health_kit_datasource.dart
+++ b/lib/features/workout/data/datasources/health_kit_datasource.dart
@@ -2,12 +2,16 @@ import 'package:health/health.dart';
 import 'package:co_workfit/core/constants/health_data_types.dart';
 import 'package:dartz/dartz.dart';
 import 'package:co_workfit/core/utils/logger.dart';
+import 'workout_details_fetcher.dart';
 
 /// HealthKit 데이터 소스
 class HealthKitDataSource {
   final Health _health;
+  final WorkoutDetailsFetcher _detailsFetcher;
 
-  HealthKitDataSource({Health? health}) : _health = health ?? Health();
+  HealthKitDataSource({Health? health})
+      : _health = health ?? Health(),
+        _detailsFetcher = WorkoutDetailsFetcher(health: health);
 
   /// HealthKit 권한 요청
   /// Returns: Right(true) if authorized, Left(error) if failed
@@ -86,7 +90,10 @@ class HealthKitDataSource {
   }
 
   /// 특정 운동에 대한 상세 데이터 가져오기 (칼로리, 심박수 등)
+  ///
   /// 거리 데이터는 WORKOUT의 totalDistance를 직접 사용하므로 여기서는 조회하지 않음
+  /// (중복 합산 방지)
+  ///
   /// [workoutStart]: 운동 시작 시간
   /// [workoutEnd]: 운동 종료 시간
   /// Returns: 운동 상세 데이터 Map
@@ -94,84 +101,10 @@ class HealthKitDataSource {
     required DateTime workoutStart,
     required DateTime workoutEnd,
   }) async {
-    try {
-      final details = <String, dynamic>{};
-
-      // 칼로리 데이터
-      final caloriesData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.ACTIVE_ENERGY_BURNED],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (caloriesData.isNotEmpty) {
-        final totalCalories = caloriesData.fold<double>(
-          0,
-          (sum, point) => sum + (point.value as NumericHealthValue).numericValue,
-        );
-        details['calories'] = totalCalories.round();
-      }
-
-      // 거리 데이터는 WORKOUT 자체의 totalDistance를 사용하므로 여기서는 조회하지 않음
-      // (중복 합산 방지)
-
-      // 걸음 수
-      final stepsData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.STEPS],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (stepsData.isNotEmpty) {
-        final totalSteps = stepsData.fold<double>(
-          0,
-          (sum, point) => sum + (point.value as NumericHealthValue).numericValue,
-        );
-        details['steps'] = totalSteps.round();
-      }
-
-      // 심박수 데이터
-      final heartRateData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.HEART_RATE],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (heartRateData.isNotEmpty) {
-        final heartRates = heartRateData
-            .map((point) => (point.value as NumericHealthValue).numericValue)
-            .toList();
-
-        if (heartRates.isNotEmpty) {
-          final avgHeartRate =
-              heartRates.reduce((a, b) => a + b) / heartRates.length;
-          final maxHeartRate = heartRates.reduce((a, b) => a > b ? a : b);
-
-          details['averageHeartRate'] = avgHeartRate.round();
-          details['maxHeartRate'] = maxHeartRate.round();
-        }
-      }
-
-      // 계단 오른 층수 (고도 게인 계산에 사용)
-      final flightsData = await _health.getHealthDataFromTypes(
-        types: [HealthDataType.FLIGHTS_CLIMBED],
-        startTime: workoutStart,
-        endTime: workoutEnd,
-      );
-
-      if (flightsData.isNotEmpty) {
-        final totalFlights = flightsData.fold<double>(
-          0,
-          (sum, point) => sum + (point.value as NumericHealthValue).numericValue,
-        );
-        // 1 flight ≈ 3 meters
-        details['elevationGain'] = totalFlights * 3.0;
-      }
-
-      return Right(details);
-    } catch (e) {
-      return Left('운동 상세 데이터 가져오기 실패: ${e.toString()}');
-    }
+    return _detailsFetcher.fetchWorkoutDetails(
+      workoutStart: workoutStart,
+      workoutEnd: workoutEnd,
+    );
   }
 
   /// HealthKit 사용 가능 여부 확인

--- a/lib/features/workout/data/datasources/workout_details_fetcher.dart
+++ b/lib/features/workout/data/datasources/workout_details_fetcher.dart
@@ -1,0 +1,157 @@
+import 'package:health/health.dart';
+import 'package:dartz/dartz.dart';
+
+/// 운동 상세 데이터 조회를 위한 공통 헬퍼 클래스
+///
+/// iOS (HealthKit)와 Android (Health Connect) 모두에서
+/// 칼로리, 걸음수, 심박수, 고도 등의 상세 데이터를 조회하는 로직을 공통화합니다.
+///
+/// 주의: 거리 데이터는 WORKOUT의 totalDistance를 사용하므로 여기서 조회하지 않습니다.
+class WorkoutDetailsFetcher {
+  final Health _health;
+
+  WorkoutDetailsFetcher({Health? health}) : _health = health ?? Health();
+
+  /// 특정 운동에 대한 상세 데이터 가져오기
+  ///
+  /// [workoutStart]: 운동 시작 시간
+  /// [workoutEnd]: 운동 종료 시간
+  /// [includeElevation]: 고도 데이터 포함 여부 (일부 플랫폼에서 지원 안 될 수 있음)
+  /// Returns: 운동 상세 데이터 Map (calories, steps, averageHeartRate, maxHeartRate, elevationGain)
+  Future<Either<String, Map<String, dynamic>>> fetchWorkoutDetails({
+    required DateTime workoutStart,
+    required DateTime workoutEnd,
+    bool includeElevation = true,
+  }) async {
+    try {
+      final details = <String, dynamic>{};
+
+      // 칼로리
+      final calories = await _fetchCalories(workoutStart, workoutEnd);
+      if (calories != null) {
+        details['calories'] = calories;
+      }
+
+      // 걸음 수
+      final steps = await _fetchSteps(workoutStart, workoutEnd);
+      if (steps != null) {
+        details['steps'] = steps;
+      }
+
+      // 심박수 (평균, 최대)
+      final heartRateData = await _fetchHeartRate(workoutStart, workoutEnd);
+      if (heartRateData != null) {
+        details.addAll(heartRateData);
+      }
+
+      // 고도 (옵션)
+      if (includeElevation) {
+        final elevationGain = await _fetchElevationGain(workoutStart, workoutEnd);
+        if (elevationGain != null) {
+          details['elevationGain'] = elevationGain;
+        }
+      }
+
+      return Right(details);
+    } catch (e) {
+      return Left('운동 상세 데이터 가져오기 실패: ${e.toString()}');
+    }
+  }
+
+  /// 칼로리 데이터 조회
+  Future<int?> _fetchCalories(DateTime start, DateTime end) async {
+    try {
+      final caloriesData = await _health.getHealthDataFromTypes(
+        types: [HealthDataType.ACTIVE_ENERGY_BURNED],
+        startTime: start,
+        endTime: end,
+      );
+
+      if (caloriesData.isEmpty) return null;
+
+      final totalCalories = caloriesData.fold<double>(
+        0,
+        (sum, point) => sum + (point.value as NumericHealthValue).numericValue,
+      );
+
+      return totalCalories.round();
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// 걸음 수 데이터 조회
+  Future<int?> _fetchSteps(DateTime start, DateTime end) async {
+    try {
+      final stepsData = await _health.getHealthDataFromTypes(
+        types: [HealthDataType.STEPS],
+        startTime: start,
+        endTime: end,
+      );
+
+      if (stepsData.isEmpty) return null;
+
+      final totalSteps = stepsData.fold<double>(
+        0,
+        (sum, point) => sum + (point.value as NumericHealthValue).numericValue,
+      );
+
+      return totalSteps.round();
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// 심박수 데이터 조회 (평균, 최대)
+  Future<Map<String, int>?> _fetchHeartRate(DateTime start, DateTime end) async {
+    try {
+      final heartRateData = await _health.getHealthDataFromTypes(
+        types: [HealthDataType.HEART_RATE],
+        startTime: start,
+        endTime: end,
+      );
+
+      if (heartRateData.isEmpty) return null;
+
+      final heartRates = heartRateData
+          .map((point) => (point.value as NumericHealthValue).numericValue)
+          .toList();
+
+      if (heartRates.isEmpty) return null;
+
+      final avgHeartRate = heartRates.reduce((a, b) => a + b) / heartRates.length;
+      final maxHeartRate = heartRates.reduce((a, b) => a > b ? a : b);
+
+      return {
+        'averageHeartRate': avgHeartRate.round(),
+        'maxHeartRate': maxHeartRate.round(),
+      };
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// 고도 데이터 조회 (계단 오른 층수 기반)
+  Future<double?> _fetchElevationGain(DateTime start, DateTime end) async {
+    try {
+      final flightsData = await _health.getHealthDataFromTypes(
+        types: [HealthDataType.FLIGHTS_CLIMBED],
+        startTime: start,
+        endTime: end,
+      );
+
+      if (flightsData.isEmpty) return null;
+
+      final totalFlights = flightsData.fold<double>(
+        0,
+        (sum, point) => sum + (point.value as NumericHealthValue).numericValue,
+      );
+
+      // 1 flight ≈ 3 meters
+      return totalFlights * 3.0;
+    } catch (e) {
+      // 일부 플랫폼에서 지원되지 않을 수 있음
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## 문제점
- 안드로이드에서 러닝 거리가 일정하지 않게 잘못 계산되는 문제
- iOS와 Android DataSource 코드 중복 (270줄)

## 원인 분석

### 1. DISTANCE_DELTA 사용 문제 ⚠️
- 여러 앱(Samsung Health, Google Fit)에서 **중복 기록**
- 운동 전후 이동도 포함되어 **부정확함**
- 시간 범위 내 모든 거리를 합산하여 실제 운동 거리와 불일치

### 2. 위치 권한 부족 가능성
- WORKOUT totalDistance를 읽으려면 **위치 권한** 필요
- 권한 없으면 totalDistance가 null

## 해결 방법

### ✅ DISTANCE_DELTA 제거
- Health Connect와 Google Fit에서 DISTANCE_DELTA 조회 **완전 제거**
- WORKOUT의 totalDistance만 사용 (iOS와 동일하게)
- 부정확한 거리 계산 문제 **해결**

### ✅ 코드 공통화 및 리팩토링

**WorkoutDetailsFetcher 클래스 신규 생성:**
- iOS/Android 공통 로직 통합 (칼로리, 걸음수, 심박수, 고도)
- 중복 코드 **270줄 → 0줄 제거**
- 유지보수성 향상 (한 곳만 수정하면 모든 플랫폼 적용)

**리팩토링 결과:**
- HealthKit: 78줄 → 16줄 **(-79%)**
- Health Connect: 94줄 → 19줄 **(-80%)**
- Google Fit: 98줄 → 17줄 **(-83%)**

### ✅ 로깅 및 문서화 개선
- WORKOUT totalDistance 값 로깅 추가
- 위치 권한 필요성 문서화
- DISTANCE_DELTA 미사용 이유 주석 추가
- 공식 문서 링크 추가

## 변경 파일
- ✨ `workout_details_fetcher.dart`: **신규 생성** (공통 헬퍼 클래스)
- 🔧 `health_kit_datasource.dart`: 리팩토링 (WorkoutDetailsFetcher 사용)
- 🔧 `health_connect_datasource.dart`: 리팩토링 + DISTANCE_DELTA 제거
- 🔧 `google_fit_datasource.dart`: 리팩토링 + DISTANCE_DELTA 제거
- 🔧 `health_data_mapper.dart`: totalDistance null 처리 개선

## 테스트
- [x] flutter analyze: **0 errors** (기존 37개 이슈는 다른 파일)
- [x] 단위 변환 로직 유지 (METER/MILE → KM)
- [x] iOS와 Android 로직 일치

## 참고 문서
- [Health Connect data types](https://developer.android.com/health-and-fitness/guides/health-connect/plan/data-types)
- [Google Fit Data types](https://developers.google.com/fit/datatypes)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)