### PR TITLE
[Phase 5] 통나무런에서 displayName 대신 nickname 사용

### DIFF
--- a/lib/features/log_run/data/datasources/firestore_log_run_datasource.dart
+++ b/lib/features/log_run/data/datasources/firestore_log_run_datasource.dart
@@ -14,7 +14,7 @@ class FirestoreLogRunDataSource {
   FirestoreLogRunDataSource({required this.firestore});
 
   Future<LogRunChallengeModel> createChallenge({
-    required String userId, required String userName, required double targetWeight,
+    required String userId, required String userNickname, required double targetWeight,
     int? recordTimeLimit, bool? allowFutureRecordsOnly, DateTime? expiresAt,
   }) async {
     final now = DateTime.now();
@@ -43,10 +43,10 @@ class FirestoreLogRunDataSource {
     }
 
     await challengeRef.set({
-      'createdBy': userId, 'creatorName': userName,
+      'createdBy': userId, 'creatorNickname': userNickname,
       'targetWeight': targetWeight, 'targetDistance': targetWeight,
       'currentDistance': 0.0, 'remainingWeight': targetWeight,
-      'participants': [userId], 'participantNames': {userId: userName},
+      'participants': [userId], 'participantNicknames': {userId: userNickname},
       'status': ChallengeStatus.active.toFirestore(),
       'createdAt': Timestamp.fromDate(now),
       'inviteCode': inviteCode,
@@ -59,22 +59,22 @@ class FirestoreLogRunDataSource {
     return LogRunChallengeModel.fromFirestore(doc);
   }
 
-  Future<void> joinChallenge({required String challengeId, required String userId, required String userName}) async {
+  Future<void> joinChallenge({required String challengeId, required String userId, required String userNickname}) async {
     await firestore.collection(_challengesCollection).doc(challengeId).update({
       'participants': FieldValue.arrayUnion([userId]),
-      'participantNames.$userId': userName,
+      'participantNicknames.$userId': userNickname,
     });
   }
 
   Future<void> leaveChallenge({required String challengeId, required String userId}) async {
     await firestore.collection(_challengesCollection).doc(challengeId).update({
       'participants': FieldValue.arrayRemove([userId]),
-      'participantNames.$userId': FieldValue.delete(),
+      'participantNicknames.$userId': FieldValue.delete(),
     });
   }
 
   Future<LogRunContributionModel> submitWorkout({
-    required String challengeId, required String userId, required String userName,
+    required String challengeId, required String userId, required String userNickname,
     required String workoutId, required double distance, required String workoutType, required DateTime workoutDate
   }) async {
     return await firestore.runTransaction<LogRunContributionModel>((transaction) async {
@@ -95,14 +95,14 @@ class FirestoreLogRunDataSource {
       final contributionRef = challengeRef.collection(_contributionsSubcollection).doc();
       final now = DateTime.now();
       transaction.set(contributionRef, {
-        'challengeId': challengeId, 'userId': userId, 'userName': userName,
+        'challengeId': challengeId, 'userId': userId, 'userNickname': userNickname,
         'workoutId': workoutId, 'distance': distance, 'workoutType': workoutType,
         'workoutDate': Timestamp.fromDate(workoutDate), 'submittedAt': Timestamp.fromDate(now),
         'percentage': percentage,
       });
 
       return LogRunContributionModel(
-        id: contributionRef.id, challengeId: challengeId, userId: userId, userName: userName,
+        id: contributionRef.id, challengeId: challengeId, userId: userId, userNickname: userNickname,
         workoutId: workoutId, distance: distance, workoutType: _parseWorkoutType(workoutType),
         workoutDate: workoutDate, submittedAt: now, percentage: percentage,
       );

--- a/lib/features/log_run/data/models/log_run_contribution_model.dart
+++ b/lib/features/log_run/data/models/log_run_contribution_model.dart
@@ -4,7 +4,7 @@ import 'package:co_workfit/features/workout/domain/entities/workout_entity.dart'
 
 class LogRunContributionModel extends LogRunContributionEntity {
   const LogRunContributionModel({
-    required super.id, required super.challengeId, required super.userId, required super.userName,
+    required super.id, required super.challengeId, required super.userId, required super.userNickname,
     required super.workoutId, required super.distance, required super.workoutType,
     required super.workoutDate, required super.submittedAt, required super.percentage,
   });
@@ -13,7 +13,7 @@ class LogRunContributionModel extends LogRunContributionEntity {
     final data = doc.data() as Map<String, dynamic>;
     return LogRunContributionModel(
       id: doc.id, challengeId: data['challengeId'] as String, userId: data['userId'] as String,
-      userName: data['userName'] as String, workoutId: data['workoutId'] as String,
+      userNickname: data['userNickname'] as String, workoutId: data['workoutId'] as String,
       distance: (data['distance'] as num).toDouble(),
       workoutType: _parseWorkoutType(data['workoutType'] as String),
       workoutDate: (data['workoutDate'] as Timestamp).toDate(),
@@ -24,7 +24,7 @@ class LogRunContributionModel extends LogRunContributionEntity {
 
   Map<String, dynamic> toFirestore() {
     return {
-      'challengeId': challengeId, 'userId': userId, 'userName': userName,
+      'challengeId': challengeId, 'userId': userId, 'userNickname': userNickname,
       'workoutId': workoutId, 'distance': distance,
       'workoutType': workoutType.toString().split('.').last,
       'workoutDate': Timestamp.fromDate(workoutDate),
@@ -34,7 +34,7 @@ class LogRunContributionModel extends LogRunContributionEntity {
 
   factory LogRunContributionModel.fromEntity(LogRunContributionEntity entity) {
     return LogRunContributionModel(
-      id: entity.id, challengeId: entity.challengeId, userId: entity.userId, userName: entity.userName,
+      id: entity.id, challengeId: entity.challengeId, userId: entity.userId, userNickname: entity.userNickname,
       workoutId: entity.workoutId, distance: entity.distance, workoutType: entity.workoutType,
       workoutDate: entity.workoutDate, submittedAt: entity.submittedAt, percentage: entity.percentage,
     );

--- a/lib/features/log_run/data/repositories/log_run_repository_impl.dart
+++ b/lib/features/log_run/data/repositories/log_run_repository_impl.dart
@@ -11,11 +11,11 @@ class LogRunRepositoryImpl implements LogRunRepository {
 
   @override
   Future<Either<Failure, LogRunChallengeEntity>> createChallenge({
-    required String userId, required String userName, required double targetWeight,
+    required String userId, required String userNickname, required double targetWeight,
     int? recordTimeLimit, bool? allowFutureRecordsOnly, DateTime? expiresAt,
   }) async {
     try {
-      final challenge = await dataSource.createChallenge(userId: userId, userName: userName,
+      final challenge = await dataSource.createChallenge(userId: userId, userNickname: userNickname,
         targetWeight: targetWeight, recordTimeLimit: recordTimeLimit,
         allowFutureRecordsOnly: allowFutureRecordsOnly, expiresAt: expiresAt);
       return Right(challenge);
@@ -25,9 +25,9 @@ class LogRunRepositoryImpl implements LogRunRepository {
   }
 
   @override
-  Future<Either<Failure, void>> joinChallenge({required String challengeId, required String userId, required String userName}) async {
+  Future<Either<Failure, void>> joinChallenge({required String challengeId, required String userId, required String userNickname}) async {
     try {
-      await dataSource.joinChallenge(challengeId: challengeId, userId: userId, userName: userName);
+      await dataSource.joinChallenge(challengeId: challengeId, userId: userId, userNickname: userNickname);
       return const Right(null);
     } catch (e) { return Left(ServerFailure(e.toString())); }
   }
@@ -42,11 +42,11 @@ class LogRunRepositoryImpl implements LogRunRepository {
 
   @override
   Future<Either<Failure, LogRunContributionEntity>> submitWorkout({
-    required String challengeId, required String userId, required String userName,
+    required String challengeId, required String userId, required String userNickname,
     required String workoutId, required double distance, required String workoutType, required DateTime workoutDate
   }) async {
     try {
-      final contribution = await dataSource.submitWorkout(challengeId: challengeId, userId: userId, userName: userName,
+      final contribution = await dataSource.submitWorkout(challengeId: challengeId, userId: userId, userNickname: userNickname,
         workoutId: workoutId, distance: distance, workoutType: workoutType, workoutDate: workoutDate);
       return Right(contribution);
     } catch (e) { return Left(ServerFailure(e.toString())); }

--- a/lib/features/log_run/domain/entities/log_run_contribution_entity.dart
+++ b/lib/features/log_run/domain/entities/log_run_contribution_entity.dart
@@ -14,8 +14,8 @@ class LogRunContributionEntity extends Equatable {
   /// 사용자 ID
   final String userId;
 
-  /// 사용자 이름
-  final String userName;
+  /// 사용자 닉네임
+  final String userNickname;
 
   /// 원본 운동 기록 ID (중복 방지용)
   final String workoutId;
@@ -39,7 +39,7 @@ class LogRunContributionEntity extends Equatable {
     required this.id,
     required this.challengeId,
     required this.userId,
-    required this.userName,
+    required this.userNickname,
     required this.workoutId,
     required this.distance,
     required this.workoutType,
@@ -53,7 +53,7 @@ class LogRunContributionEntity extends Equatable {
         id,
         challengeId,
         userId,
-        userName,
+        userNickname,
         workoutId,
         distance,
         workoutType,

--- a/lib/features/log_run/domain/repositories/log_run_repository.dart
+++ b/lib/features/log_run/domain/repositories/log_run_repository.dart
@@ -8,7 +8,7 @@ abstract class LogRunRepository {
   /// 챌린지 생성
   Future<Either<Failure, LogRunChallengeEntity>> createChallenge({
     required String userId,
-    required String userName,
+    required String userNickname,
     required double targetWeight,
     int? recordTimeLimit,
     bool? allowFutureRecordsOnly,
@@ -19,7 +19,7 @@ abstract class LogRunRepository {
   Future<Either<Failure, void>> joinChallenge({
     required String challengeId,
     required String userId,
-    required String userName,
+    required String userNickname,
   });
 
   /// 챌린지 탈퇴
@@ -32,7 +32,7 @@ abstract class LogRunRepository {
   Future<Either<Failure, LogRunContributionEntity>> submitWorkout({
     required String challengeId,
     required String userId,
-    required String userName,
+    required String userNickname,
     required String workoutId,
     required double distance,
     required String workoutType,

--- a/lib/features/log_run/domain/usecases/create_log_run_challenge.dart
+++ b/lib/features/log_run/domain/usecases/create_log_run_challenge.dart
@@ -14,7 +14,7 @@ class CreateLogRunChallenge implements UseCase<LogRunChallengeEntity, CreateChal
   Future<Either<Failure, LogRunChallengeEntity>> call(CreateChallengeParams params) async {
     return await repository.createChallenge(
       userId: params.userId,
-      userName: params.userName,
+      userNickname: params.userNickname,
       targetWeight: params.targetWeight,
       recordTimeLimit: params.recordTimeLimit,
       allowFutureRecordsOnly: params.allowFutureRecordsOnly,
@@ -25,7 +25,7 @@ class CreateLogRunChallenge implements UseCase<LogRunChallengeEntity, CreateChal
 
 class CreateChallengeParams {
   final String userId;
-  final String userName;
+  final String userNickname;
   final double targetWeight;
   final int? recordTimeLimit;
   final bool? allowFutureRecordsOnly;
@@ -33,7 +33,7 @@ class CreateChallengeParams {
 
   CreateChallengeParams({
     required this.userId,
-    required this.userName,
+    required this.userNickname,
     required this.targetWeight,
     this.recordTimeLimit,
     this.allowFutureRecordsOnly,

--- a/lib/features/log_run/domain/usecases/join_challenge_by_invite_code.dart
+++ b/lib/features/log_run/domain/usecases/join_challenge_by_invite_code.dart
@@ -49,7 +49,7 @@ class JoinChallengeByInviteCode
         final joinResult = await repository.joinChallenge(
           challengeId: challenge.id,
           userId: params.userId,
-          userName: params.userName,
+          userNickname: params.userNickname,
         );
 
         return joinResult.fold(
@@ -64,11 +64,11 @@ class JoinChallengeByInviteCode
 class JoinByCodeParams {
   final String inviteCode;
   final String userId;
-  final String userName;
+  final String userNickname;
 
   JoinByCodeParams({
     required this.inviteCode,
     required this.userId,
-    required this.userName,
+    required this.userNickname,
   });
 }

--- a/lib/features/log_run/domain/usecases/join_log_run_challenge.dart
+++ b/lib/features/log_run/domain/usecases/join_log_run_challenge.dart
@@ -14,7 +14,7 @@ class JoinLogRunChallenge implements UseCase<void, JoinChallengeParams> {
     return await repository.joinChallenge(
       challengeId: params.challengeId,
       userId: params.userId,
-      userName: params.userName,
+      userNickname: params.userNickname,
     );
   }
 }
@@ -22,11 +22,11 @@ class JoinLogRunChallenge implements UseCase<void, JoinChallengeParams> {
 class JoinChallengeParams {
   final String challengeId;
   final String userId;
-  final String userName;
+  final String userNickname;
 
   JoinChallengeParams({
     required this.challengeId,
     required this.userId,
-    required this.userName,
+    required this.userNickname,
   });
 }

--- a/lib/features/log_run/domain/usecases/submit_workout_to_challenge.dart
+++ b/lib/features/log_run/domain/usecases/submit_workout_to_challenge.dart
@@ -15,7 +15,7 @@ class SubmitWorkoutToChallenge implements UseCase<LogRunContributionEntity, Subm
     return await repository.submitWorkout(
       challengeId: params.challengeId,
       userId: params.userId,
-      userName: params.userName,
+      userNickname: params.userNickname,
       workoutId: params.workoutId,
       distance: params.distance,
       workoutType: params.workoutType,
@@ -27,7 +27,7 @@ class SubmitWorkoutToChallenge implements UseCase<LogRunContributionEntity, Subm
 class SubmitWorkoutParams {
   final String challengeId;
   final String userId;
-  final String userName;
+  final String userNickname;
   final String workoutId;
   final double distance;
   final String workoutType;
@@ -36,7 +36,7 @@ class SubmitWorkoutParams {
   SubmitWorkoutParams({
     required this.challengeId,
     required this.userId,
-    required this.userName,
+    required this.userNickname,
     required this.workoutId,
     required this.distance,
     required this.workoutType,

--- a/lib/features/log_run/presentation/bloc/log_run_bloc.dart
+++ b/lib/features/log_run/presentation/bloc/log_run_bloc.dart
@@ -127,7 +127,7 @@ class LogRunBloc extends Bloc<LogRunEvent, LogRunState> {
     final result = await createChallengeUseCase(
       CreateChallengeParams(
         userId: event.userId,
-        userName: event.userName,
+        userNickname: event.userNickname,
         targetWeight: event.targetWeight,
         recordTimeLimit: event.recordTimeLimit,
         allowFutureRecordsOnly: event.allowFutureRecordsOnly,
@@ -152,7 +152,7 @@ class LogRunBloc extends Bloc<LogRunEvent, LogRunState> {
       JoinChallengeParams(
         challengeId: event.challengeId,
         userId: event.userId,
-        userName: event.userName,
+        userNickname: event.userNickname,
       ),
     );
 
@@ -175,7 +175,7 @@ class LogRunBloc extends Bloc<LogRunEvent, LogRunState> {
       JoinByCodeParams(
         inviteCode: event.inviteCode,
         userId: event.userId,
-        userName: event.userName,
+        userNickname: event.userNickname,
       ),
     );
 
@@ -226,7 +226,7 @@ class LogRunBloc extends Bloc<LogRunEvent, LogRunState> {
       SubmitWorkoutParams(
         challengeId: event.challengeId,
         userId: event.userId,
-        userName: event.userName,
+        userNickname: event.userNickname,
         workoutId: event.workoutId,
         distance: event.distance,
         workoutType: event.workoutType,

--- a/lib/features/log_run/presentation/bloc/log_run_event.dart
+++ b/lib/features/log_run/presentation/bloc/log_run_event.dart
@@ -31,7 +31,7 @@ class LoadCompletedChallenges extends LogRunEvent {
 /// 챌린지 생성
 class CreateChallenge extends LogRunEvent {
   final String userId;
-  final String userName;
+  final String userNickname;
   final double targetWeight;
   final int? recordTimeLimit;
   final bool? allowFutureRecordsOnly;
@@ -39,7 +39,7 @@ class CreateChallenge extends LogRunEvent {
 
   const CreateChallenge({
     required this.userId,
-    required this.userName,
+    required this.userNickname,
     required this.targetWeight,
     this.recordTimeLimit,
     this.allowFutureRecordsOnly,
@@ -49,7 +49,7 @@ class CreateChallenge extends LogRunEvent {
   @override
   List<Object?> get props => [
         userId,
-        userName,
+        userNickname,
         targetWeight,
         recordTimeLimit,
         allowFutureRecordsOnly,
@@ -61,32 +61,32 @@ class CreateChallenge extends LogRunEvent {
 class JoinChallenge extends LogRunEvent {
   final String challengeId;
   final String userId;
-  final String userName;
+  final String userNickname;
 
   const JoinChallenge({
     required this.challengeId,
     required this.userId,
-    required this.userName,
+    required this.userNickname,
   });
 
   @override
-  List<Object?> get props => [challengeId, userId, userName];
+  List<Object?> get props => [challengeId, userId, userNickname];
 }
 
 /// 초대 코드로 챌린지 참가
 class JoinChallengeByCode extends LogRunEvent {
   final String inviteCode;
   final String userId;
-  final String userName;
+  final String userNickname;
 
   const JoinChallengeByCode({
     required this.inviteCode,
     required this.userId,
-    required this.userName,
+    required this.userNickname,
   });
 
   @override
-  List<Object?> get props => [inviteCode, userId, userName];
+  List<Object?> get props => [inviteCode, userId, userNickname];
 }
 
 /// 챌린지 탈퇴
@@ -107,7 +107,7 @@ class LeaveChallenge extends LogRunEvent {
 class SubmitWorkout extends LogRunEvent {
   final String challengeId;
   final String userId;
-  final String userName;
+  final String userNickname;
   final String workoutId;
   final double distance;
   final String workoutType;
@@ -116,7 +116,7 @@ class SubmitWorkout extends LogRunEvent {
   const SubmitWorkout({
     required this.challengeId,
     required this.userId,
-    required this.userName,
+    required this.userNickname,
     required this.workoutId,
     required this.distance,
     required this.workoutType,
@@ -127,7 +127,7 @@ class SubmitWorkout extends LogRunEvent {
   List<Object?> get props => [
         challengeId,
         userId,
-        userName,
+        userNickname,
         workoutId,
         distance,
         workoutType,

--- a/lib/features/log_run/presentation/pages/challenge_detail_page.dart
+++ b/lib/features/log_run/presentation/pages/challenge_detail_page.dart
@@ -43,7 +43,7 @@ class _ChallengeDetailPageState extends BasePageState<ChallengeDetailPage> {
                 SubmitWorkout(
                   challengeId: widget.challengeId,
                   userId: authState.user.id,
-                  userName: authState.user.displayName,
+                  userNickname: authState.user.nickname,
                   workoutId: workoutId,
                   distance: distance,
                   workoutType: workoutType,

--- a/lib/features/log_run/presentation/pages/log_run_page.dart
+++ b/lib/features/log_run/presentation/pages/log_run_page.dart
@@ -81,7 +81,7 @@ class _LogRunPageState extends BasePageState<LogRunPage> {
             context.read<LogRunBloc>().add(
                   CreateChallenge(
                     userId: authState.user.id,
-                    userName: authState.user.displayName,
+                    userNickname: authState.user.nickname,
                     targetWeight: targetWeight,
                   ),
                 );
@@ -106,7 +106,7 @@ class _LogRunPageState extends BasePageState<LogRunPage> {
                   JoinChallengeByCode(
                     inviteCode: inviteCode,
                     userId: authState.user.id,
-                    userName: authState.user.displayName,
+                    userNickname: authState.user.nickname,
                   ),
                 );
           }

--- a/lib/features/log_run/presentation/widgets/contribution_feed_widget.dart
+++ b/lib/features/log_run/presentation/widgets/contribution_feed_widget.dart
@@ -94,7 +94,7 @@ class _ContributionItem extends StatelessWidget {
                   Row(
                     children: [
                       Text(
-                        contribution.userName,
+                        contribution.userNickname,
                         style: Theme.of(context).textTheme.titleSmall?.copyWith(
                               fontWeight: FontWeight.bold,
                             ),


### PR DESCRIPTION
## 개요
통나무런 챌린지 및 기여 내역에서 사용자의 실명(displayName) 대신 닉네임(nickname)을 표시하도록 변경했습니다.

## 변경 사항

### Domain Layer
- ✅ `LogRunContributionEntity`: `userName` → `userNickname`
- ✅ `LogRunRepository`: 모든 메서드에서 `userName` → `userNickname`
- ✅ `CreateLogRunChallenge`, `JoinLogRunChallenge`, `JoinChallengeByInviteCode`, `SubmitWorkoutToChallenge` UseCases: parameter 변경

### Data Layer
- ✅ `LogRunContributionModel`: `userName` → `userNickname`
- ✅ `FirestoreLogRunDataSource`: 
  - Firestore 필드명 변경: `userName` → `userNickname`
  - `participantNames` → `participantNicknames`
  - `creatorName` → `creatorNickname`
- ✅ `LogRunRepositoryImpl`: 구현체 메서드 시그니처 변경

### Presentation Layer
- ✅ `LogRunEvent`: 모든 이벤트에서 `userName` → `userNickname`
- ✅ `LogRunBloc`: UseCase 호출 시 nickname 사용
- ✅ `ChallengeDetailPage`: 운동 제출 시 `user.nickname` 사용
- ✅ `LogRunPage`: 챌린지 생성 및 참가 시 `user.nickname` 사용
- ✅ `ContributionFeedWidget`: 기여 내역 표시 시 nickname 표시

## 테스트
- ✅ `flutter analyze`: 0 errors
- ✅ 모든 Layer에서 일관되게 nickname 사용 확인
- ✅ Social 및 Profile 기능은 기존대로 정상 동작

## 주의사항
### Firestore 필드명 변경
기존 데이터와의 호환성을 위해:
- 새로 생성되는 챌린지 및 기여 내역은 `userNickname` 필드 사용
- 기존 데이터는 `userName` 필드를 그대로 사용하므로 마이그레이션 필요할 수 있음
- 테스트 환경에서 먼저 확인 후 배포 권장

## 영향 범위
- `lib/features/log_run/` 전체 (14개 파일)
- Social 및 Profile 기능은 영향 없음

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)