### PR TITLE
feat: Health Debug Page에 상세한 거리 로그 추가

### DIFF
--- a/lib/features/workout/data/datasources/health_connect_datasource.dart
+++ b/lib/features/workout/data/datasources/health_connect_datasource.dart
@@ -162,14 +162,20 @@ class HealthConnectDataSource {
       final dataWithSource = healthData.map((point) {
         final source = _detectWorkoutSource(point);
 
-        // WORKOUT 데이터의 totalDistance 정보 로깅
+        // WORKOUT 데이터의 totalDistance 정보 로깅 (디버깅용)
         if (point.value is WorkoutHealthValue) {
           final workoutValue = point.value as WorkoutHealthValue;
           AppLogger.debug('HealthConnect',
-            'WORKOUT 데이터: type=${workoutValue.workoutActivityType}, '
-            'totalDistance=${workoutValue.totalDistance}, '
-            'unit=${workoutValue.totalDistanceUnit}, '
-            'source=${point.sourceName}');
+            '===== WORKOUT 레코드 =====\n'
+            'Type: ${workoutValue.workoutActivityType}\n'
+            'Start: ${point.dateFrom}\n'
+            'End: ${point.dateTo}\n'
+            'Duration: ${point.dateTo.difference(point.dateFrom).inMinutes}분\n'
+            'TotalDistance: ${workoutValue.totalDistance}\n'
+            'Unit: ${workoutValue.totalDistanceUnit}\n'
+            'Source: ${point.sourceName}\n'
+            'SourceId: ${point.sourceId}\n'
+            '========================');
         }
 
         return HealthDataPointWithSource(

--- a/lib/features/workout/presentation/pages/health_debug_page.dart
+++ b/lib/features/workout/presentation/pages/health_debug_page.dart
@@ -129,19 +129,54 @@ class _HealthDebugPageState extends State<HealthDebugPage> {
 
       _addLog('✅ 조회된 WORKOUT 데이터: ${healthData.length}개');
 
-      for (var i = 0; i < healthData.length && i < 5; i++) {
+      for (var i = 0; i < healthData.length && i < 10; i++) {
         final point = healthData[i];
         final duration = point.dateTo.difference(point.dateFrom);
-        _addLog('  [$i] ${point.type}');
-        _addLog('      시작: ${point.dateFrom.toString().substring(11, 16)}');
-        _addLog('      종료: ${point.dateTo.toString().substring(11, 16)}');
-        _addLog('      시간: ${duration.inMinutes}분');
-        _addLog('      출처: ${point.sourceName}');
-        _addLog('      ID: ${point.sourceId}');
+        _addLog('');
+        _addLog('===== WORKOUT #$i =====');
+        _addLog('Type: ${point.type}');
+        _addLog('Start: ${point.dateFrom}');
+        _addLog('End: ${point.dateTo}');
+        _addLog('Duration: ${duration.inMinutes}분');
+        _addLog('Source: ${point.sourceName}');
+        _addLog('SourceId: ${point.sourceId}');
+
+        // WorkoutHealthValue에서 거리 정보 추출
+        if (point.value is WorkoutHealthValue) {
+          final workoutValue = point.value as WorkoutHealthValue;
+          _addLog('WorkoutType: ${workoutValue.workoutActivityType}');
+          _addLog('TotalDistance: ${workoutValue.totalDistance}');
+          _addLog('DistanceUnit: ${workoutValue.totalDistanceUnit}');
+
+          // km로 환산
+          if (workoutValue.totalDistance != null && workoutValue.totalDistanceUnit != null) {
+            final rawDistance = workoutValue.totalDistance!.toDouble();
+            final unit = workoutValue.totalDistanceUnit!;
+            double distanceKm;
+
+            if (unit == HealthDataUnit.METER) {
+              distanceKm = rawDistance / 1000.0;
+              _addLog('→ ${rawDistance}m = ${distanceKm.toStringAsFixed(2)}km');
+            } else if (unit == HealthDataUnit.MILE) {
+              distanceKm = rawDistance * 1.60934;
+              _addLog('→ ${rawDistance}mi = ${distanceKm.toStringAsFixed(2)}km');
+            } else {
+              // 기본값 (미터로 가정)
+              distanceKm = rawDistance / 1000.0;
+              _addLog('→ Unknown unit: $unit (assumed meters: ${rawDistance}m = ${distanceKm.toStringAsFixed(2)}km)');
+            }
+          } else {
+            _addLog('⚠️ TotalDistance is NULL');
+          }
+
+          _addLog('Calories: ${workoutValue.totalEnergyBurned}');
+        }
+        _addLog('===================');
       }
 
-      if (healthData.length > 5) {
-        _addLog('  ... 외 ${healthData.length - 5}개');
+      if (healthData.length > 10) {
+        _addLog('');
+        _addLog('... 외 ${healthData.length - 10}개');
       }
 
       if (healthData.isEmpty) {
@@ -188,17 +223,57 @@ class _HealthDebugPageState extends State<HealthDebugPage> {
         (dataPoints) {
           _addLog('✅ 데이터 조회 성공: ${dataPoints.length}개');
 
-          for (var i = 0; i < dataPoints.length && i < 5; i++) {
+          for (var i = 0; i < dataPoints.length && i < 10; i++) {
             final data = dataPoints[i];
             final point = data.healthDataPoint;
-            _addLog('  [$i] ${point.type}');
-            _addLog('      시간: ${point.dateFrom.toString().substring(11, 16)} ~ ${point.dateTo.toString().substring(11, 16)}');
-            _addLog('      출처: ${data.detectedSource}');
-            _addLog('      Source Name: ${point.sourceName}');
+            final duration = point.dateTo.difference(point.dateFrom);
+
+            _addLog('');
+            _addLog('===== WORKOUT #$i =====');
+            _addLog('Type: ${point.type}');
+            _addLog('Start: ${point.dateFrom}');
+            _addLog('End: ${point.dateTo}');
+            _addLog('Duration: ${duration.inMinutes}분');
+            _addLog('DetectedSource: ${data.detectedSource}');
+            _addLog('SourceName: ${point.sourceName}');
+            _addLog('SourceId: ${point.sourceId}');
+
+            // WorkoutHealthValue에서 거리 정보 추출
+            if (point.value is WorkoutHealthValue) {
+              final workoutValue = point.value as WorkoutHealthValue;
+              _addLog('WorkoutType: ${workoutValue.workoutActivityType}');
+              _addLog('TotalDistance: ${workoutValue.totalDistance}');
+              _addLog('DistanceUnit: ${workoutValue.totalDistanceUnit}');
+
+              // km로 환산
+              if (workoutValue.totalDistance != null && workoutValue.totalDistanceUnit != null) {
+                final rawDistance = workoutValue.totalDistance!.toDouble();
+                final unit = workoutValue.totalDistanceUnit!;
+                double distanceKm;
+
+                if (unit == HealthDataUnit.METER) {
+                  distanceKm = rawDistance / 1000.0;
+                  _addLog('→ ${rawDistance}m = ${distanceKm.toStringAsFixed(2)}km');
+                } else if (unit == HealthDataUnit.MILE) {
+                  distanceKm = rawDistance * 1.60934;
+                  _addLog('→ ${rawDistance}mi = ${distanceKm.toStringAsFixed(2)}km');
+                } else {
+                  // 기본값 (미터로 가정)
+                  distanceKm = rawDistance / 1000.0;
+                  _addLog('→ Unknown unit: $unit (assumed meters: ${rawDistance}m = ${distanceKm.toStringAsFixed(2)}km)');
+                }
+              } else {
+                _addLog('⚠️ TotalDistance is NULL');
+              }
+
+              _addLog('Calories: ${workoutValue.totalEnergyBurned}');
+            }
+            _addLog('===================');
           }
 
-          if (dataPoints.length > 5) {
-            _addLog('  ... 외 ${dataPoints.length - 5}개');
+          if (dataPoints.length > 10) {
+            _addLog('');
+            _addLog('... 외 ${dataPoints.length - 10}개');
           }
         },
       );


### PR DESCRIPTION
## 변경 사항
- Health Debug Page에 각 WORKOUT 레코드의 상세 거리 정보 추가
- `TotalDistance`, `DistanceUnit` 출력
- 미터/마일 → km 자동 환산 표시
- 최대 10개 레코드의 상세 정보 표시
- HealthConnect datasource에도 디버그 로그 추가

## 목적
- Android 거리 계산 버그 디버깅을 위한 상세 로그 추가
- Health Connect에서 실제로 반환하는 totalDistance 값 확인
- 중복 레코드 존재 여부 확인

## 테스트
- [x] flutter analyze 통과
- [x] Health Debug Page 빌드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)