### PR TITLE
feat: iOS 배포 자동화 - Fastlane Match 설정

### DIFF
--- a/.github/workflows/deploy-ios-dev.yml
+++ b/.github/workflows/deploy-ios-dev.yml
@@ -115,6 +115,30 @@ jobs:
           sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
           xcodebuild -version
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: false
+
+      - name: Install Fastlane
+        run: |
+          cd ios
+          gem install fastlane
+          cd ..
+
+      - name: Setup Match Code Signing
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          cd ios
+          fastlane match adhoc --readonly
+          cd ..
+
       - name: Install CocoaPods dependencies
         run: |
           cd ios
@@ -122,12 +146,15 @@ jobs:
           cd ..
 
       - name: Build IPA (Ad-Hoc for Firebase)
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         run: |
           flutter clean
           flutter build ipa --release \
             --build-name=${{ steps.bump_version.outputs.version_name }} \
             --build-number=${{ steps.bump_version.outputs.build_number }} \
-            --export-method=ad-hoc
+            --export-method=ad-hoc \
+            --export-options-plist=ios/ExportOptions-AdHoc.plist
 
       - name: Get IPA info
         id: ipa_info

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app.*.map.json
 
 # Environment variables
 .envrc
+SETUP_SECRETS.md

--- a/docs/FASTLANE_MATCH_SETUP.md
+++ b/docs/FASTLANE_MATCH_SETUP.md
@@ -1,0 +1,389 @@
+# Fastlane Match 설정 가이드
+
+이 문서는 Fastlane Match를 사용하여 iOS 인증서와 프로비저닝 프로파일을 관리하고, GitHub Actions에서 자동 배포를 설정하는 방법을 안내합니다.
+
+## 📋 목차
+
+1. [Fastlane Match란?](#fastlane-match란)
+2. [사전 준비](#사전-준비)
+3. [인증서 저장소 생성](#인증서-저장소-생성)
+4. [Fastlane 설치 및 초기화](#fastlane-설치-및-초기화)
+5. [Match 설정](#match-설정)
+6. [인증서 생성](#인증서-생성)
+7. [GitHub Secrets 설정](#github-secrets-설정)
+8. [테스트](#테스트)
+9. [트러블슈팅](#트러블슈팅)
+
+---
+
+## Fastlane Match란?
+
+**Fastlane Match**는 iOS 개발 팀에서 인증서와 프로비저닝 프로파일을 안전하게 공유하고 관리하는 도구입니다.
+
+### 장점
+- ✅ 인증서 자동 생성 및 관리
+- ✅ Git 저장소에 암호화하여 안전하게 저장
+- ✅ 팀원 및 CI/CD 시스템에서 동일한 인증서 사용
+- ✅ GitHub Actions 완전 자동화
+
+### 작동 원리
+```
+1. Match가 인증서 생성
+2. 암호화하여 Git 저장소에 저장
+3. GitHub Actions에서 필요 시 다운로드 및 사용
+```
+
+---
+
+## 사전 준비
+
+### 필수 항목
+- ✅ Apple Developer Program 가입 ($99/년)
+- ✅ Mac 컴퓨터 (Fastlane 설정용)
+- ✅ GitHub 계정
+- ✅ Xcode 설치
+
+### 필요한 정보
+- Apple ID (이메일)
+- Apple Team ID (10자리)
+- Bundle ID: `com.hansol.coworkfit`
+
+---
+
+## 인증서 저장소 생성
+
+Match는 인증서를 **비공개 Git 저장소**에 저장합니다.
+
+### 1️⃣ GitHub에서 새 저장소 생성
+
+1. https://github.com/new 접속
+2. 저장소 설정:
+   - **Repository name**: `coworkfit-certificates` (또는 원하는 이름)
+   - **Description**: `iOS certificates for CoWorkFit`
+   - **Visibility**: 🔒 **Private** (필수!)
+3. **Create repository** 클릭
+
+### 2️⃣ Personal Access Token 생성
+
+Match가 저장소에 접근하려면 GitHub Token이 필요합니다.
+
+1. https://github.com/settings/tokens 접속
+2. **Generate new token** → **Generate new token (classic)** 클릭
+3. 설정:
+   - **Note**: `Fastlane Match - CoWorkfit`
+   - **Expiration**: `No expiration` (또는 1년)
+   - **Scopes**:
+     - ✅ `repo` (모든 하위 항목 체크)
+4. **Generate token** 클릭
+5. **토큰 복사** (다시 볼 수 없으니 바로 저장!)
+
+**형식 예시:**
+```
+ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+---
+
+## Fastlane 설치 및 초기화
+
+### 1️⃣ Fastlane 설치
+
+```bash
+# Mac에서 실행
+sudo gem install fastlane
+```
+
+### 2️⃣ iOS 폴더로 이동
+
+```bash
+cd /path/to/co-workfit/ios
+```
+
+### 3️⃣ Fastlane 초기화
+
+```bash
+fastlane init
+```
+
+**물어보는 것들:**
+
+```
+What would you like to use fastlane for?
+→ 4. 🚀 Manual setup
+
+Apple ID Username:
+→ (당신의 Apple ID 이메일 입력)
+```
+
+---
+
+## Match 설정
+
+### 1️⃣ Match 초기화
+
+```bash
+cd ios
+fastlane match init
+```
+
+**물어보는 것들:**
+
+```
+Where do you want to store your certificates?
+1. git
+2. google_cloud
+3. s3
+4. gitlab_secure_files
+
+→ 1 (git 선택)
+
+URL of the Git Repo:
+→ https://github.com/lppresident/coworkfit-certificates.git
+(위에서 생성한 저장소 URL)
+```
+
+### 2️⃣ Matchfile 확인
+
+`ios/fastlane/Matchfile` 파일이 생성됩니다:
+
+```ruby
+git_url("https://github.com/lppresident/coworkfit-certificates.git")
+
+storage_mode("git")
+
+type("development") # The default type, can be: appstore, adhoc, enterprise or development
+```
+
+### 3️⃣ Matchfile 수정 (선택사항)
+
+더 명확하게 설정하려면:
+
+```ruby
+git_url("https://github.com/lppresident/coworkfit-certificates.git")
+storage_mode("git")
+
+app_identifier("com.hansol.coworkfit")
+username("your-apple-id@example.com") # Apple ID
+team_id("DRPP364BVT") # Apple Team ID
+```
+
+---
+
+## 인증서 생성
+
+### 1️⃣ 환경 변수 설정
+
+```bash
+# GitHub Personal Access Token 설정
+export MATCH_GIT_BASIC_AUTHORIZATION=$(echo -n "your-github-username:ghp_your_token" | base64)
+
+# Match 암호 설정 (나중에 GitHub Secrets에도 사용)
+export MATCH_PASSWORD="your-secure-password-here"
+```
+
+**암호 규칙:**
+- 최소 8자 이상
+- 안전한 암호 사용 (나중에 필요!)
+- **절대 잊지 마세요!**
+
+### 2️⃣ Development 인증서 생성
+
+```bash
+cd ios
+fastlane match development
+```
+
+**물어보는 것들:**
+
+```
+Apple ID:
+→ (자동으로 채워져 있음, Enter)
+
+Team ID:
+→ (목록에서 선택 또는 입력)
+
+Passphrase for Git Repo:
+→ (위에서 설정한 MATCH_PASSWORD 입력, 두 번)
+```
+
+### 3️⃣ Ad-Hoc 인증서 생성 (Firebase 배포용)
+
+```bash
+fastlane match adhoc
+```
+
+### 4️⃣ App Store 인증서 생성 (TestFlight용)
+
+```bash
+fastlane match appstore
+```
+
+### 5️⃣ 확인
+
+인증서가 생성되었는지 확인:
+
+```bash
+# Git 저장소 확인
+git clone https://github.com/lppresident/coworkfit-certificates.git /tmp/certs
+ls -la /tmp/certs
+# certs/, profiles/ 폴더가 있어야 함
+```
+
+---
+
+## GitHub Secrets 설정
+
+### 필요한 Secrets
+
+다음 3개의 Secrets를 GitHub에 추가합니다:
+
+#### 1️⃣ MATCH_PASSWORD
+
+Match로 인증서를 암호화할 때 사용한 암호입니다.
+
+```
+위에서 설정한 암호
+```
+
+#### 2️⃣ MATCH_GIT_BASIC_AUTHORIZATION
+
+GitHub Personal Access Token을 Base64로 인코딩한 값입니다.
+
+```bash
+# 생성 방법
+echo -n "your-github-username:ghp_your_token" | base64
+```
+
+**예시:**
+```bash
+echo -n "lppresident:ghp_xxxxxxxxxxxx" | base64
+# 출력: bHByZXNpZGVudDpnaHBfeHh4eHh4eHh4eHh4
+```
+
+#### 3️⃣ MATCH_GIT_URL
+
+인증서 저장소 URL입니다.
+
+```
+https://github.com/lppresident/coworkfit-certificates.git
+```
+
+### GitHub Secrets 추가
+
+1. https://github.com/lppresident/co-workfit/settings/secrets/actions 접속
+2. **New repository secret** 클릭
+3. 3개 Secret 추가:
+
+**Secret 1:**
+- Name: `MATCH_PASSWORD`
+- Secret: (Match 암호)
+
+**Secret 2:**
+- Name: `MATCH_GIT_BASIC_AUTHORIZATION`
+- Secret: (Base64 인코딩된 토큰)
+
+**Secret 3:**
+- Name: `MATCH_GIT_URL`
+- Secret: `https://github.com/lppresident/coworkfit-certificates.git`
+
+---
+
+## 테스트
+
+### 로컬에서 테스트
+
+```bash
+cd ios
+
+# Match로 인증서 다운로드 테스트
+fastlane match adhoc --readonly
+
+# iOS 빌드 테스트
+cd ..
+flutter build ipa --release
+```
+
+성공하면 `build/ios/ipa/co_workfit.ipa` 파일이 생성됩니다!
+
+---
+
+## 트러블슈팅
+
+### 문제 1: "Passphrase is incorrect"
+
+**원인**: MATCH_PASSWORD가 틀렸습니다.
+
+**해결:**
+```bash
+# 올바른 암호로 다시 설정
+export MATCH_PASSWORD="correct-password"
+fastlane match adhoc --readonly
+```
+
+### 문제 2: "Invalid credentials"
+
+**원인**: GitHub Token이 만료되었거나 권한이 없습니다.
+
+**해결:**
+1. GitHub에서 Token 재생성
+2. `MATCH_GIT_BASIC_AUTHORIZATION` 재설정
+
+### 문제 3: "No certificates found"
+
+**원인**: 인증서가 아직 생성되지 않았습니다.
+
+**해결:**
+```bash
+cd ios
+fastlane match adhoc  # readonly 빼고 실행
+```
+
+### 문제 4: "Team ID not found"
+
+**원인**: Apple Team ID가 잘못되었습니다.
+
+**해결:**
+1. https://developer.apple.com/account 접속
+2. Membership에서 Team ID 확인
+3. Matchfile에서 `team_id` 수정
+
+### 문제 5: GitHub Actions에서 실패
+
+**원인**: Secrets가 올바르게 설정되지 않았습니다.
+
+**해결:**
+1. GitHub Secrets 확인
+2. Secret 이름 대소문자 확인
+3. Base64 인코딩 다시 확인
+
+---
+
+## 📚 참고 자료
+
+- [Fastlane Match 공식 문서](https://docs.fastlane.tools/actions/match/)
+- [Fastlane 설치 가이드](https://docs.fastlane.tools/getting-started/ios/setup/)
+- [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+
+---
+
+## ✅ 완료 체크리스트
+
+- [ ] Fastlane 설치
+- [ ] 인증서 저장소 생성 (Private)
+- [ ] GitHub Personal Access Token 생성
+- [ ] Match 초기화
+- [ ] Development 인증서 생성
+- [ ] Ad-Hoc 인증서 생성
+- [ ] App Store 인증서 생성
+- [ ] GitHub Secrets 3개 추가
+  - [ ] MATCH_PASSWORD
+  - [ ] MATCH_GIT_BASIC_AUTHORIZATION
+  - [ ] MATCH_GIT_URL
+- [ ] 로컬 빌드 테스트
+- [ ] GitHub Actions 배포 테스트
+
+---
+
+**작성일**: 2025-12-26
+**버전**: 1.0
+**관련 이슈**: #35, #41

--- a/docs/GITHUB_SECRETS_SETUP.md
+++ b/docs/GITHUB_SECRETS_SETUP.md
@@ -1,0 +1,264 @@
+# GitHub Secrets 설정 가이드
+
+이 문서는 Co-WorkFit iOS 배포를 위한 GitHub Secrets 설정 방법을 단계별로 안내합니다.
+
+## 📋 목차
+
+1. [GitHub Secrets 설정 위치](#github-secrets-설정-위치)
+2. [Firebase Secrets](#firebase-secrets)
+3. [Apple Secrets](#apple-secrets)
+4. [설정 확인](#설정-확인)
+
+---
+
+## GitHub Secrets 설정 위치
+
+1. GitHub 리포지토리 접속: https://github.com/lppresident/co-workfit
+2. **Settings** 탭 클릭
+3. 좌측 메뉴에서 **Secrets and variables** → **Actions** 클릭
+4. **New repository secret** 버튼으로 각 Secret 추가
+
+---
+
+## Firebase Secrets
+
+### 1️⃣ FIREBASE_IOS_APP_ID
+
+Firebase iOS 앱 ID를 설정합니다.
+
+#### 찾는 방법:
+
+1. [Firebase Console](https://console.firebase.google.com/) 접속
+2. **co-workfit** 프로젝트 선택
+3. 좌측 상단 톱니바퀴 아이콘 → **프로젝트 설정** 클릭
+4. **일반** 탭에서 아래로 스크롤
+5. **내 앱** 섹션에서 iOS 앱 찾기
+   - **앱이 없으면**: "앱 추가" → iOS 선택 → Bundle ID: `com.hansol.coworkfit` 입력
+6. **앱 ID** 복사
+
+**형식 예시:**
+```
+1:123456789012:ios:abcdef1234567890abcdef
+```
+
+#### GitHub Secret 추가:
+- **Name**: `FIREBASE_IOS_APP_ID`
+- **Secret**: 위에서 복사한 앱 ID
+
+---
+
+### 2️⃣ FIREBASE_SERVICE_ACCOUNT
+
+Firebase Admin SDK 서비스 계정 JSON 파일입니다.
+
+#### 찾는 방법:
+
+1. [Firebase Console](https://console.firebase.google.com/) 접속
+2. **co-workfit** 프로젝트 선택
+3. 좌측 상단 톱니바퀴 아이콘 → **프로젝트 설정** 클릭
+4. **서비스 계정** 탭 클릭
+5. **새 비공개 키 생성** 버튼 클릭
+6. **키 생성** 확인 → JSON 파일 다운로드됨
+7. 다운로드한 JSON 파일을 텍스트 에디터로 열기
+8. **전체 내용** 복사
+
+**JSON 형식 예시:**
+```json
+{
+  "type": "service_account",
+  "project_id": "co-workfit",
+  "private_key_id": "abcdef1234567890...",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg...\n-----END PRIVATE KEY-----\n",
+  "client_email": "firebase-adminsdk-xxxxx@co-workfit.iam.gserviceaccount.com",
+  "client_id": "123456789012345678901",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/..."
+}
+```
+
+#### GitHub Secret 추가:
+- **Name**: `FIREBASE_SERVICE_ACCOUNT`
+- **Secret**: JSON 파일 전체 내용 붙여넣기 (줄바꿈 포함)
+
+---
+
+## Apple Secrets
+
+### 3️⃣ APPLE_ID
+
+Apple Developer 계정의 Apple ID (이메일 주소)입니다.
+
+#### 찾는 방법:
+
+Apple Developer Program에 가입할 때 사용한 이메일 주소입니다.
+
+**예시:**
+```
+your-email@example.com
+```
+
+#### GitHub Secret 추가:
+- **Name**: `APPLE_ID`
+- **Secret**: Apple ID 이메일 주소
+
+---
+
+### 4️⃣ APPLE_APP_SPECIFIC_PASSWORD
+
+App Store Connect용 앱 전용 암호입니다.
+
+#### 생성 방법:
+
+1. [Apple ID 계정 페이지](https://appleid.apple.com/) 접속
+2. Apple ID로 로그인
+3. **로그인 및 보안** 섹션으로 이동
+4. **앱 암호** (App-Specific Passwords) 클릭
+5. **+** 버튼 또는 **암호 생성** 클릭
+6. 레이블 입력 (예: `GitHub Actions CoWorkfit`)
+7. **생성** 클릭
+8. 생성된 암호 복사 (다시 볼 수 없으니 바로 복사!)
+
+**형식 예시:**
+```
+abcd-efgh-ijkl-mnop
+```
+
+⚠️ **중요**: 이 암호는 생성 후 다시 볼 수 없습니다! 바로 복사하여 저장하세요.
+
+#### GitHub Secret 추가:
+- **Name**: `APPLE_APP_SPECIFIC_PASSWORD`
+- **Secret**: 생성된 앱 전용 암호
+
+---
+
+### 5️⃣ APPLE_TEAM_ID
+
+Apple Developer Team ID입니다.
+
+#### 찾는 방법:
+
+**방법 1: Apple Developer Portal**
+1. [Apple Developer Portal](https://developer.apple.com/account) 접속
+2. 로그인
+3. 우측 상단 사용자 이름 아래에 Team ID 표시됨
+   - 또는 **Membership** 메뉴 클릭
+4. **Team ID** 복사 (10자리 영문/숫자)
+
+**방법 2: App Store Connect**
+1. [App Store Connect](https://appstoreconnect.apple.com/) 접속
+2. **Users and Access** 클릭
+3. **Keys** 탭 클릭 (또는 **Integrations** → **API Keys**)
+4. Issuer ID 아래에 있는 항목 확인
+   - 또는 상단에 Team ID가 표시됨
+
+**방법 3: Xcode**
+1. Xcode에서 프로젝트 열기
+2. **Signing & Capabilities** 탭
+3. **Team** 드롭다운 옆에 Team ID 표시
+
+**형식 예시:**
+```
+A1B2C3D4E5
+```
+
+#### GitHub Secret 추가:
+- **Name**: `APPLE_TEAM_ID`
+- **Secret**: 10자리 Team ID
+
+---
+
+## 설정 확인
+
+### 모든 Secrets 확인
+
+GitHub 리포지토리 → Settings → Secrets and variables → Actions에서 다음 항목들이 모두 있는지 확인:
+
+#### Firebase (iOS Dev 배포용)
+- ✅ `FIREBASE_IOS_APP_ID`
+- ✅ `FIREBASE_SERVICE_ACCOUNT`
+
+#### Apple (TestFlight 배포용)
+- ✅ `APPLE_ID`
+- ✅ `APPLE_APP_SPECIFIC_PASSWORD`
+- ✅ `APPLE_TEAM_ID`
+
+### 기존 Android Secrets (이미 설정되어 있어야 함)
+- ✅ `FIREBASE_APP_ID` (Android 앱 ID)
+
+---
+
+## 배포 실행
+
+모든 Secrets 설정이 완료되면:
+
+### iOS Dev/QA 배포 (Firebase App Distribution)
+
+1. GitHub 리포지토리 → **Actions** 탭
+2. **Deploy iOS (Dev/QA)** 워크플로우 선택
+3. **Run workflow** 버튼 클릭
+4. 옵션 선택:
+   - **version_bump**: `build` (첫 배포)
+   - **release_notes**: `iOS 첫 배포 테스트`
+   - **deploy_to_firebase**: ✅ true
+   - **deploy_to_github**: ✅ true
+5. **Run workflow** 버튼 클릭
+
+**필요한 Secrets:**
+- `FIREBASE_IOS_APP_ID`
+- `FIREBASE_SERVICE_ACCOUNT`
+
+---
+
+### iOS Beta 배포 (TestFlight)
+
+1. GitHub 리포지토리 → **Actions** 탭
+2. **Deploy iOS (Beta)** 워크플로우 선택
+3. **Run workflow** 버튼 클릭
+4. 옵션 선택:
+   - **version_bump**: `build`
+   - **release_notes**: `TestFlight 베타 테스트`
+   - **upload_to_testflight**: ✅ true
+   - **deploy_to_github**: ✅ true
+5. **Run workflow** 버튼 클릭
+
+**필요한 Secrets:**
+- `APPLE_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
+- `APPLE_TEAM_ID`
+
+---
+
+## 트러블슈팅
+
+### "Secret not found" 에러
+- GitHub Settings → Secrets에서 Secret 이름 철자 확인
+- 대소문자 구분 확인 (정확히 일치해야 함)
+
+### Firebase 배포 실패
+- `FIREBASE_IOS_APP_ID` 형식 확인 (콜론 `:` 포함)
+- `FIREBASE_SERVICE_ACCOUNT` JSON 전체 복사 확인
+
+### Apple 인증 실패
+- `APPLE_APP_SPECIFIC_PASSWORD`가 올바른지 확인
+- Apple ID에서 2단계 인증이 활성화되어 있는지 확인
+- `APPLE_TEAM_ID`가 10자리인지 확인
+
+### 인증서/프로비저닝 에러
+- Xcode에서 Signing & Capabilities 설정 확인
+- Apple Developer Portal에서 인증서 상태 확인
+
+---
+
+## 참고 자료
+
+- [Firebase Console](https://console.firebase.google.com/)
+- [Apple Developer Portal](https://developer.apple.com/account)
+- [App Store Connect](https://appstoreconnect.apple.com/)
+- [Apple ID 계정 페이지](https://appleid.apple.com/)
+
+---
+
+**작성일**: 2025-12-26
+**버전**: 1.0

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -32,3 +32,10 @@ Runner/GeneratedPluginRegistrant.*
 !default.mode2v3
 !default.pbxuser
 !default.perspectivev3
+
+# Fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+fastlane/README.md

--- a/ios/ExportOptions-AdHoc.plist
+++ b/ios/ExportOptions-AdHoc.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>ad-hoc</string>
+	<key>teamID</key>
+	<string>DRPP364BVT</string>
+	<key>signingCertificate</key>
+	<string>Apple Distribution</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.hansol.coworkfit</key>
+		<string>match AdHoc com.hansol.coworkfit</string>
+	</dict>
+	<key>compileBitcode</key>
+	<false/>
+	<key>uploadBitcode</key>
+	<false/>
+	<key>uploadSymbols</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/ExportOptions-AppStore.plist
+++ b/ios/ExportOptions-AppStore.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>app-store</string>
+	<key>teamID</key>
+	<string>DRPP364BVT</string>
+	<key>signingCertificate</key>
+	<string>Apple Distribution</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.hansol.coworkfit</key>
+		<string>match AppStore com.hansol.coworkfit</string>
+	</dict>
+	<key>compileBitcode</key>
+	<false/>
+	<key>uploadBitcode</key>
+	<false/>
+	<key>uploadSymbols</key>
+	<true/>
+</dict>
+</plist>

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,0 +1,8 @@
+app_identifier("com.hansol.coworkfit") # The bundle identifier of your app
+apple_id(ENV["APPLE_ID"]) # Your Apple email address
+
+itc_team_id(ENV["APPLE_TEAM_ID"]) # App Store Connect Team ID
+team_id("DRPP364BVT") # Developer Portal Team ID
+
+# For more information about the Appfile, see:
+#     https://docs.fastlane.tools/advanced/#appfile

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,0 +1,89 @@
+# This file contains the fastlane.tools configuration
+# You can find the documentation at https://docs.fastlane.tools
+#
+# For a list of all available actions, check out
+#
+#     https://docs.fastlane.tools/actions
+#
+# For a list of all available plugins, check out
+#
+#     https://docs.fastlane.tools/plugins/available-plugins
+#
+
+# Uncomment the line if you want fastlane to automatically update itself
+# update_fastlane
+
+default_platform(:ios)
+
+platform :ios do
+  desc "Sync certificates and profiles using Match"
+  lane :sync_code_signing do |options|
+    type = options[:type] || "adhoc"
+
+    match(
+      type: type,
+      readonly: true,
+      app_identifier: "com.hansol.coworkfit"
+    )
+  end
+
+  desc "Build IPA for Firebase App Distribution (Ad-Hoc)"
+  lane :build_adhoc do |options|
+    # Sync certificates
+    sync_code_signing(type: "adhoc")
+
+    # Build
+    build_app(
+      scheme: "Runner",
+      export_method: "ad-hoc",
+      export_options: {
+        method: "ad-hoc",
+        provisioningProfiles: {
+          "com.hansol.coworkfit" => "match AdHoc com.hansol.coworkfit"
+        }
+      }
+    )
+  end
+
+  desc "Build IPA for TestFlight (App Store)"
+  lane :build_appstore do |options|
+    # Sync certificates
+    sync_code_signing(type: "appstore")
+
+    # Build
+    build_app(
+      scheme: "Runner",
+      export_method: "app-store",
+      export_options: {
+        method: "app-store",
+        provisioningProfiles: {
+          "com.hansol.coworkfit" => "match AppStore com.hansol.coworkfit"
+        }
+      }
+    )
+  end
+
+  desc "Upload to Firebase App Distribution"
+  lane :firebase do |options|
+    firebase_app_distribution(
+      app: ENV["FIREBASE_IOS_APP_ID"],
+      service_credentials_file: "firebase-credentials.json",
+      groups: "testers",
+      release_notes: options[:release_notes] || "New build from CI"
+    )
+  end
+
+  desc "Upload to TestFlight"
+  lane :beta do |options|
+    # Build
+    build_appstore
+
+    # Upload to TestFlight
+    upload_to_testflight(
+      skip_waiting_for_build_processing: true,
+      apple_id: ENV["APPLE_ID"],
+      app_identifier: "com.hansol.coworkfit",
+      team_id: ENV["APPLE_TEAM_ID"]
+    )
+  end
+end

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -1,0 +1,13 @@
+git_url(ENV["MATCH_GIT_URL"] || "https://github.com/lppresident/coworkfit-certificates.git")
+
+storage_mode("git")
+
+type("adhoc") # Default type
+
+app_identifier(["com.hansol.coworkfit"])
+
+# Apple Team ID (found in Apple Developer Portal)
+team_id("DRPP364BVT")
+
+# For more information about the Appfile, see:
+#     https://docs.fastlane.tools/advanced/#appfile

--- a/scripts/setup-fastlane-match.sh
+++ b/scripts/setup-fastlane-match.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+
+# Fastlane Match 설정 스크립트
+# 이 스크립트는 Fastlane Match를 처음 설정할 때 사용합니다.
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}  Fastlane Match 설정${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Check if running on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo -e "${RED}이 스크립트는 macOS에서만 실행할 수 있습니다.${NC}"
+    exit 1
+fi
+
+# Check if Fastlane is installed
+if ! command -v fastlane &> /dev/null; then
+    echo -e "${YELLOW}Fastlane이 설치되지 않았습니다. 설치를 진행합니다...${NC}"
+    sudo gem install fastlane
+    echo -e "${GREEN}✓ Fastlane 설치 완료${NC}"
+else
+    echo -e "${GREEN}✓ Fastlane이 이미 설치되어 있습니다.${NC}"
+fi
+
+echo ""
+echo -e "${BLUE}1. 인증서 저장소 설정${NC}"
+echo -e "${YELLOW}인증서를 저장할 비공개 GitHub 저장소를 생성하셨나요?${NC}"
+echo -e "예: https://github.com/lppresident/coworkfit-certificates"
+read -p "저장소 URL을 입력하세요: " MATCH_GIT_URL
+
+if [ -z "$MATCH_GIT_URL" ]; then
+    echo -e "${RED}저장소 URL이 필요합니다.${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${BLUE}2. GitHub Personal Access Token 설정${NC}"
+echo -e "${YELLOW}GitHub Personal Access Token을 생성하셨나요?${NC}"
+echo -e "생성 방법: https://github.com/settings/tokens"
+read -sp "GitHub Token을 입력하세요: " GITHUB_TOKEN
+echo ""
+
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo -e "${RED}GitHub Token이 필요합니다.${NC}"
+    exit 1
+fi
+
+# GitHub username 추출
+GITHUB_USERNAME=$(echo "$MATCH_GIT_URL" | sed -n 's|.*/github.com/\([^/]*\)/.*|\1|p')
+echo -e "${GREEN}✓ GitHub Username: $GITHUB_USERNAME${NC}"
+
+# Base64 인코딩
+MATCH_GIT_BASIC_AUTH=$(echo -n "$GITHUB_USERNAME:$GITHUB_TOKEN" | base64)
+
+echo ""
+echo -e "${BLUE}3. Match 암호 설정${NC}"
+echo -e "${YELLOW}인증서를 암호화할 비밀번호를 입력하세요 (최소 8자)${NC}"
+read -sp "MATCH_PASSWORD: " MATCH_PASSWORD
+echo ""
+read -sp "MATCH_PASSWORD 확인: " MATCH_PASSWORD_CONFIRM
+echo ""
+
+if [ "$MATCH_PASSWORD" != "$MATCH_PASSWORD_CONFIRM" ]; then
+    echo -e "${RED}비밀번호가 일치하지 않습니다.${NC}"
+    exit 1
+fi
+
+if [ ${#MATCH_PASSWORD} -lt 8 ]; then
+    echo -e "${RED}비밀번호는 최소 8자 이상이어야 합니다.${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${BLUE}4. 환경 변수 설정${NC}"
+export MATCH_GIT_URL="$MATCH_GIT_URL"
+export MATCH_GIT_BASIC_AUTHORIZATION="$MATCH_GIT_BASIC_AUTH"
+export MATCH_PASSWORD="$MATCH_PASSWORD"
+
+echo -e "${GREEN}✓ 환경 변수 설정 완료${NC}"
+
+echo ""
+echo -e "${BLUE}5. Matchfile 업데이트${NC}"
+cat > ios/fastlane/Matchfile << EOF
+git_url("$MATCH_GIT_URL")
+
+storage_mode("git")
+
+type("adhoc") # Default type
+
+app_identifier(["com.hansol.coworkfit"])
+
+# Apple Team ID
+team_id("DRPP364BVT")
+EOF
+
+echo -e "${GREEN}✓ Matchfile 생성 완료${NC}"
+
+echo ""
+echo -e "${BLUE}6. Match 인증서 생성${NC}"
+echo -e "${YELLOW}Apple ID와 Team ID가 필요합니다.${NC}"
+read -p "계속하시겠습니까? (y/n): " CONTINUE
+
+if [ "$CONTINUE" != "y" ]; then
+    echo -e "${YELLOW}나중에 다음 명령어로 인증서를 생성하세요:${NC}"
+    echo -e "  cd ios"
+    echo -e "  fastlane match adhoc"
+    echo -e "  fastlane match appstore"
+    exit 0
+fi
+
+cd ios
+
+echo ""
+echo -e "${BLUE}6-1. Ad-Hoc 인증서 생성 (Firebase 배포용)${NC}"
+fastlane match adhoc
+
+echo ""
+echo -e "${BLUE}6-2. App Store 인증서 생성 (TestFlight 배포용)${NC}"
+fastlane match appstore
+
+cd ..
+
+echo ""
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}  설정 완료!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo -e "${BLUE}다음 단계:${NC}"
+echo ""
+echo -e "1. ${YELLOW}GitHub Secrets 추가${NC}"
+echo -e "   https://github.com/lppresident/co-workfit/settings/secrets/actions"
+echo ""
+echo -e "   ${GREEN}MATCH_PASSWORD:${NC}"
+echo -e "   $MATCH_PASSWORD"
+echo ""
+echo -e "   ${GREEN}MATCH_GIT_BASIC_AUTHORIZATION:${NC}"
+echo -e "   $MATCH_GIT_BASIC_AUTH"
+echo ""
+echo -e "   ${GREEN}MATCH_GIT_URL:${NC}"
+echo -e "   $MATCH_GIT_URL"
+echo ""
+echo -e "2. ${YELLOW}GitHub Actions에서 iOS 배포 실행${NC}"
+echo -e "   https://github.com/lppresident/co-workfit/actions"
+echo ""
+echo -e "${BLUE}자세한 내용은 docs/FASTLANE_MATCH_SETUP.md를 참고하세요.${NC}"
+echo ""


### PR DESCRIPTION
## 개요
Fastlane Match를 사용하여 iOS 인증서 관리 및 배포 자동화를 구현했습니다.

## 변경사항

### 🔐 Fastlane Match 설정
- **Matchfile**: Match 저장소 및 기본 설정
- **Appfile**: Apple ID 및 Team 정보
- **Fastfile**: 빌드 및 배포 레인 정의

### 📦 Export 설정
- **ExportOptions-AdHoc.plist**: Firebase App Distribution용
- **ExportOptions-AppStore.plist**: TestFlight용

### 🤖 GitHub Actions 통합
- **deploy-ios-dev.yml**: Match로 인증서 자동 다운로드 및 빌드

### 🛠️ 자동화 스크립트
- **scripts/setup-fastlane-match.sh**: 대화형 설정 스크립트
  - 인증서 저장소 설정
  - GitHub Token 설정
  - Match 암호 설정
  - 인증서 생성

### 📚 문서
- **docs/FASTLANE_MATCH_SETUP.md**: 단계별 설정 가이드
- **docs/GITHUB_SECRETS_SETUP.md**: Secrets 설정 방법 (기존)

## 사용 방법

### 1️⃣ 로컬에서 설정 (최초 1회)

```bash
# 대화형 설정 스크립트 실행
./scripts/setup-fastlane-match.sh
```

또는 수동 설정:

```bash
# 1. 인증서 저장소 생성 (Private)
# https://github.com/new
# 저장소 이름: coworkfit-certificates

# 2. GitHub Personal Access Token 생성
# https://github.com/settings/tokens
# Scopes: repo (전체)

# 3. Match 인증서 생성
cd ios
export MATCH_GIT_URL="https://github.com/lppresident/coworkfit-certificates.git"
export MATCH_GIT_BASIC_AUTHORIZATION="$(echo -n 'username:token' | base64)"
export MATCH_PASSWORD="your-secure-password"

fastlane match adhoc      # Firebase 배포용
fastlane match appstore   # TestFlight 배포용
```

### 2️⃣ GitHub Secrets 설정

https://github.com/lppresident/co-workfit/settings/secrets/actions

**필수 Secrets (3개):**

1. **MATCH_PASSWORD**
   - Match 인증서 암호화 비밀번호
   - 위에서 설정한 비밀번호

2. **MATCH_GIT_BASIC_AUTHORIZATION**
   - GitHub Token (Base64 인코딩)
   - `echo -n "username:ghp_token" | base64`

3. **MATCH_GIT_URL**
   - 인증서 저장소 URL
   - `https://github.com/lppresident/coworkfit-certificates.git`

### 3️⃣ GitHub Actions에서 배포

1. Actions 탭 → **Deploy iOS (Dev/QA)** 선택
2. **Run workflow** 클릭
3. 자동으로 Match가 인증서 다운로드 및 빌드!

## 장점

### ✅ 자동화
- 인증서 자동 생성 및 관리
- CI/CD 완전 자동화
- 수동 작업 불필요

### ✅ 보안
- Git 저장소에 암호화하여 저장
- 팀 전체 안전하게 공유
- GitHub Secrets로 민감 정보 보호

### ✅ 편의성
- 기기 UDID 등록 불필요 (App Store 배포 시)
- 여러 기기에서 동일한 인증서 사용
- 인증서 만료 걱정 없음

### ✅ 확장성
- 여러 앱에 재사용 가능
- 팀원 추가 시 간단히 공유
- 다양한 배포 타겟 지원

## 체크리스트

### 설정 완료
- [x] Fastlane Match 파일 추가
- [x] GitHub Actions 워크플로우 업데이트
- [x] Export Options plist 추가
- [x] 자동 설정 스크립트 추가
- [x] 상세 가이드 문서 작성

### 사용자 작업 필요
- [ ] 인증서 저장소 생성 (Private)
- [ ] GitHub Personal Access Token 생성
- [ ] Match 인증서 생성 (로컬에서 1회)
- [ ] GitHub Secrets 3개 추가
- [ ] GitHub Actions 배포 테스트

## 참고 문서

- [docs/FASTLANE_MATCH_SETUP.md](docs/FASTLANE_MATCH_SETUP.md) - 상세 설정 가이드
- [Fastlane Match 공식 문서](https://docs.fastlane.tools/actions/match/)

## 관련 이슈

Closes #35

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)