### PR TITLE
feat: 친구 상세 페이지 구현 및 친구 삭제 기능 (#66)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,1 +1,33 @@
-{"flutter":{"platforms":{"android":{"default":{"projectId":"co-workfit","appId":"1:89240730998:android:836909febed94e5c438e57","fileOutput":"android/app/google-services.json"}},"ios":{"default":{"projectId":"co-workfit","appId":"1:89240730998:ios:39bc3d830c3894d9438e57","uploadDebugSymbols":false,"fileOutput":"ios/Runner/GoogleService-Info.plist"}},"dart":{"lib/firebase_options.dart":{"projectId":"co-workfit","configurations":{"android":"1:89240730998:android:836909febed94e5c438e57","ios":"1:89240730998:ios:39bc3d830c3894d9438e57"}}}}}}
+{
+  "firestore": {
+    "indexes": "firestore.indexes.json"
+  },
+  "flutter": {
+    "platforms": {
+      "android": {
+        "default": {
+          "projectId": "co-workfit",
+          "appId": "1:89240730998:android:836909febed94e5c438e57",
+          "fileOutput": "android/app/google-services.json"
+        }
+      },
+      "ios": {
+        "default": {
+          "projectId": "co-workfit",
+          "appId": "1:89240730998:ios:39bc3d830c3894d9438e57",
+          "uploadDebugSymbols": false,
+          "fileOutput": "ios/Runner/GoogleService-Info.plist"
+        }
+      },
+      "dart": {
+        "lib/firebase_options.dart": {
+          "projectId": "co-workfit",
+          "configurations": {
+            "android": "1:89240730998:android:836909febed94e5c438e57",
+            "ios": "1:89240730998:ios:39bc3d830c3894d9438e57"
+          }
+        }
+      }
+    }
+  }
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,39 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "friend_requests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "receiverId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "friend_requests",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "senderId", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "friends",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "friends",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "userId", "order": "ASCENDING" },
+        { "fieldPath": "friendId", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -52,6 +52,7 @@ import 'package:co_workfit/features/social/domain/usecases/get_received_friend_r
 import 'package:co_workfit/features/social/domain/usecases/accept_friend_request.dart';
 import 'package:co_workfit/features/social/domain/usecases/reject_friend_request.dart';
 import 'package:co_workfit/features/social/domain/usecases/search_users_by_nickname.dart';
+import 'package:co_workfit/features/social/domain/usecases/remove_friend.dart';
 import 'package:co_workfit/features/social/domain/usecases/get_leaderboard.dart';
 import 'package:co_workfit/features/social/domain/usecases/get_friends_leaderboard.dart';
 import 'package:co_workfit/features/social/presentation/bloc/social_bloc.dart';
@@ -226,6 +227,7 @@ Future<void> initializeDependencies() async {
   sl.registerLazySingleton(() => AcceptFriendRequest(sl()));
   sl.registerLazySingleton(() => RejectFriendRequest(sl()));
   sl.registerLazySingleton(() => SearchUsersByNickname(sl()));
+  sl.registerLazySingleton(() => RemoveFriend(sl()));
 
   // Use Cases - Leaderboard
   sl.registerLazySingleton(() => GetLeaderboard(sl()));
@@ -241,6 +243,7 @@ Future<void> initializeDependencies() async {
       acceptFriendRequest: sl(),
       rejectFriendRequest: sl(),
       searchUsersByNickname: sl(),
+      removeFriend: sl(),
     ),
   );
 

--- a/lib/features/social/data/datasources/firestore_social_datasource.dart
+++ b/lib/features/social/data/datasources/firestore_social_datasource.dart
@@ -235,6 +235,7 @@ class FirestoreSocialDataSource {
   // ========== 친구 관계 관련 ==========
 
   /// 친구 데이터 통합 조회 (친구 목록 + 받은 요청)
+  /// 친구와 요청자의 상세 정보도 함께 조회
   Future<Either<String, FriendsDataEntity>> getFriendsData(
     String userId,
   ) async {
@@ -244,7 +245,6 @@ class FirestoreSocialDataSource {
 
     try {
       AppLogger.info('FirestoreSocialDataSource', 'getFriendsData 시작 - userId: $userId');
-      AppLogger.info('FirestoreSocialDataSource', 'friendRequestsCollection: ${FirebaseConfig.friendRequestsCollection}');
 
       // 두 쿼리를 병렬로 실행
       final results = await Future.wait([
@@ -269,21 +269,58 @@ class FirestoreSocialDataSource {
       AppLogger.info('FirestoreSocialDataSource', 'friends 개수: ${friendsSnapshot.docs.length}');
       AppLogger.info('FirestoreSocialDataSource', 'requests 개수: ${requestsSnapshot.docs.length}');
 
-      // Friends 파싱
+      // 친구들과 요청자들의 userId 수집
+      final friendIds = friendsSnapshot.docs
+          .map((doc) => doc.data()['friendId'] as String)
+          .toList();
+      final senderIds = requestsSnapshot.docs
+          .map((doc) => doc.data()['senderId'] as String)
+          .toList();
+
+      // 모든 관련 사용자 ID 합치기 (중복 제거)
+      final allUserIds = {...friendIds, ...senderIds}.toList();
+
+      // 사용자 정보 조회 (10개씩 배치 - Firestore 제한)
+      final Map<String, Map<String, dynamic>> usersMap = {};
+      for (int i = 0; i < allUserIds.length; i += 10) {
+        final batch = allUserIds.skip(i).take(10).toList();
+        if (batch.isNotEmpty) {
+          final usersSnapshot = await _firestore
+              .collection(FirebaseConfig.usersCollection)
+              .where(FieldPath.documentId, whereIn: batch)
+              .get();
+
+          for (final doc in usersSnapshot.docs) {
+            usersMap[doc.id] = doc.data();
+          }
+        }
+      }
+
+      // Friends 파싱 (사용자 정보 포함)
       final friends = friendsSnapshot.docs.map((doc) {
         final data = doc.data();
+        final friendId = data['friendId'] as String;
+        final friendData = usersMap[friendId];
+
         return FriendshipEntity(
           id: doc.id,
           userId: data['userId'] as String,
-          friendId: data['friendId'] as String,
+          friendId: friendId,
           createdAt: (data['createdAt'] as Timestamp).toDate(),
+          friendName: friendData?['displayName'] as String?,
+          friendEmail: friendData?['email'] as String?,
+          friendPhotoUrl: friendData?['photoUrl'] as String?,
+          friendTotalScore: (friendData?['totalScore'] as num?)?.toInt(),
+          friendWorkoutCount: (friendData?['workoutCount'] as num?)?.toInt(),
         );
       }).toList();
 
-      // Requests 파싱
-      final requests = requestsSnapshot.docs
-          .map((doc) => FriendRequestModel.fromFirestore(doc))
-          .toList();
+      // Requests 파싱 (보낸 사람 정보 포함)
+      final requests = requestsSnapshot.docs.map((doc) {
+        final senderId = doc.data()['senderId'] as String;
+        final senderData = usersMap[senderId] ?? {};
+        return FriendRequestModel.fromFirestoreWithSender(doc, senderData);
+      }).toList();
 
       return Right(FriendsDataEntity(
         friends: friends,
@@ -292,17 +329,11 @@ class FirestoreSocialDataSource {
       ));
     } catch (e) {
       AppLogger.error('FirestoreSocialDataSource', '친구 데이터 조회 실패', e);
-      print('========================================');
-      print('친구 데이터 조회 에러 상세 정보:');
-      print('Error: $e');
-      print('UserId: $userId');
-      print('Collection: ${FirebaseConfig.friendRequestsCollection}');
-      print('========================================');
       return Left('친구 데이터 조회에 실패했습니다: $e');
     }
   }
 
-  /// 친구 목록 가져오기
+  /// 친구 목록 가져오기 (친구 정보 포함)
   Future<Either<String, List<FriendshipEntity>>> getFriends(
     String userId,
   ) async {
@@ -317,13 +348,46 @@ class FirestoreSocialDataSource {
           .orderBy('createdAt', descending: true)
           .get();
 
+      if (snapshot.docs.isEmpty) {
+        return const Right([]);
+      }
+
+      // 친구들의 userId 수집
+      final friendIds = snapshot.docs
+          .map((doc) => doc.data()['friendId'] as String)
+          .toList();
+
+      // 사용자 정보 조회 (10개씩 배치 - Firestore 제한)
+      final Map<String, Map<String, dynamic>> usersMap = {};
+      for (int i = 0; i < friendIds.length; i += 10) {
+        final batch = friendIds.skip(i).take(10).toList();
+        if (batch.isNotEmpty) {
+          final usersSnapshot = await _firestore
+              .collection(FirebaseConfig.usersCollection)
+              .where(FieldPath.documentId, whereIn: batch)
+              .get();
+
+          for (final doc in usersSnapshot.docs) {
+            usersMap[doc.id] = doc.data();
+          }
+        }
+      }
+
       final friends = snapshot.docs.map((doc) {
         final data = doc.data();
+        final friendId = data['friendId'] as String;
+        final friendData = usersMap[friendId];
+
         return FriendshipEntity(
           id: doc.id,
           userId: data['userId'] as String,
-          friendId: data['friendId'] as String,
+          friendId: friendId,
           createdAt: (data['createdAt'] as Timestamp).toDate(),
+          friendName: friendData?['displayName'] as String?,
+          friendEmail: friendData?['email'] as String?,
+          friendPhotoUrl: friendData?['photoUrl'] as String?,
+          friendTotalScore: (friendData?['totalScore'] as num?)?.toInt(),
+          friendWorkoutCount: (friendData?['workoutCount'] as num?)?.toInt(),
         );
       }).toList();
 

--- a/lib/features/social/data/models/friend_request_model.dart
+++ b/lib/features/social/data/models/friend_request_model.dart
@@ -14,6 +14,9 @@ class FriendRequestModel extends FriendRequestEntity {
     required super.status,
     required super.createdAt,
     super.respondedAt,
+    super.senderName,
+    super.senderEmail,
+    super.senderPhotoUrl,
   });
 
   factory FriendRequestModel.fromJson(Map<String, dynamic> json) =>
@@ -38,6 +41,30 @@ class FriendRequestModel extends FriendRequestEntity {
     );
   }
 
+  /// Firestore에서 가져온 데이터에 sender 정보를 추가하여 생성
+  factory FriendRequestModel.fromFirestoreWithSender(
+    DocumentSnapshot doc,
+    Map<String, dynamic> senderData,
+  ) {
+    final data = doc.data() as Map<String, dynamic>;
+    return FriendRequestModel(
+      id: doc.id,
+      senderId: data['senderId'] as String,
+      receiverId: data['receiverId'] as String,
+      status: FriendRequestStatus.values.firstWhere(
+        (e) => e.name == data['status'],
+        orElse: () => FriendRequestStatus.pending,
+      ),
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+      respondedAt: data['respondedAt'] != null
+          ? (data['respondedAt'] as Timestamp).toDate()
+          : null,
+      senderName: senderData['displayName'] as String?,
+      senderEmail: senderData['email'] as String?,
+      senderPhotoUrl: senderData['photoUrl'] as String?,
+    );
+  }
+
   Map<String, dynamic> toFirestore() {
     return {
       'senderId': senderId,
@@ -57,6 +84,9 @@ class FriendRequestModel extends FriendRequestEntity {
       status: entity.status,
       createdAt: entity.createdAt,
       respondedAt: entity.respondedAt,
+      senderName: entity.senderName,
+      senderEmail: entity.senderEmail,
+      senderPhotoUrl: entity.senderPhotoUrl,
     );
   }
 
@@ -68,6 +98,9 @@ class FriendRequestModel extends FriendRequestEntity {
     FriendRequestStatus? status,
     DateTime? createdAt,
     DateTime? respondedAt,
+    String? senderName,
+    String? senderEmail,
+    String? senderPhotoUrl,
   }) {
     return FriendRequestModel(
       id: id ?? this.id,
@@ -76,6 +109,9 @@ class FriendRequestModel extends FriendRequestEntity {
       status: status ?? this.status,
       createdAt: createdAt ?? this.createdAt,
       respondedAt: respondedAt ?? this.respondedAt,
+      senderName: senderName ?? this.senderName,
+      senderEmail: senderEmail ?? this.senderEmail,
+      senderPhotoUrl: senderPhotoUrl ?? this.senderPhotoUrl,
     );
   }
 }

--- a/lib/features/social/domain/entities/friend_request_entity.dart
+++ b/lib/features/social/domain/entities/friend_request_entity.dart
@@ -9,8 +9,8 @@ enum FriendRequestStatus {
 
 /// 친구 요청 엔티티
 ///
-/// senderId와 receiverId(userId)만 저장하는 참조 구조
-/// 보낸 사람의 실제 정보는 UI에서 users 컬렉션에서 조회
+/// senderId와 receiverId(userId)를 저장하고,
+/// UI 표시를 위해 보낸 사람의 정보도 함께 포함
 class FriendRequestEntity extends Equatable {
   final String id;
   final String senderId; // 보낸 사람의 userId
@@ -19,6 +19,11 @@ class FriendRequestEntity extends Equatable {
   final DateTime createdAt;
   final DateTime? respondedAt;
 
+  // 보낸 사람의 정보 (UI 표시용)
+  final String? senderName;
+  final String? senderEmail;
+  final String? senderPhotoUrl;
+
   const FriendRequestEntity({
     required this.id,
     required this.senderId,
@@ -26,6 +31,9 @@ class FriendRequestEntity extends Equatable {
     required this.status,
     required this.createdAt,
     this.respondedAt,
+    this.senderName,
+    this.senderEmail,
+    this.senderPhotoUrl,
   });
 
   @override
@@ -36,6 +44,9 @@ class FriendRequestEntity extends Equatable {
         status,
         createdAt,
         respondedAt,
+        senderName,
+        senderEmail,
+        senderPhotoUrl,
       ];
 
   FriendRequestEntity copyWith({
@@ -45,6 +56,9 @@ class FriendRequestEntity extends Equatable {
     FriendRequestStatus? status,
     DateTime? createdAt,
     DateTime? respondedAt,
+    String? senderName,
+    String? senderEmail,
+    String? senderPhotoUrl,
   }) {
     return FriendRequestEntity(
       id: id ?? this.id,
@@ -53,6 +67,9 @@ class FriendRequestEntity extends Equatable {
       status: status ?? this.status,
       createdAt: createdAt ?? this.createdAt,
       respondedAt: respondedAt ?? this.respondedAt,
+      senderName: senderName ?? this.senderName,
+      senderEmail: senderEmail ?? this.senderEmail,
+      senderPhotoUrl: senderPhotoUrl ?? this.senderPhotoUrl,
     );
   }
 }

--- a/lib/features/social/domain/entities/friendship_entity.dart
+++ b/lib/features/social/domain/entities/friendship_entity.dart
@@ -2,19 +2,31 @@ import 'package:equatable/equatable.dart';
 
 /// 친구 관계 엔티티
 ///
-/// userId와 friendId(userId)만 저장하는 참조 구조
-/// 친구의 실제 정보는 UI에서 users 컬렉션에서 조회
+/// userId와 friendId를 저장하고,
+/// UI 표시를 위해 친구의 정보도 함께 포함
 class FriendshipEntity extends Equatable {
   final String id;
   final String userId;
   final String friendId; // 친구의 userId
   final DateTime createdAt;
 
+  // 친구의 정보 (UI 표시용)
+  final String? friendName;
+  final String? friendEmail;
+  final String? friendPhotoUrl;
+  final int? friendTotalScore;
+  final int? friendWorkoutCount;
+
   const FriendshipEntity({
     required this.id,
     required this.userId,
     required this.friendId,
     required this.createdAt,
+    this.friendName,
+    this.friendEmail,
+    this.friendPhotoUrl,
+    this.friendTotalScore,
+    this.friendWorkoutCount,
   });
 
   @override
@@ -23,6 +35,11 @@ class FriendshipEntity extends Equatable {
         userId,
         friendId,
         createdAt,
+        friendName,
+        friendEmail,
+        friendPhotoUrl,
+        friendTotalScore,
+        friendWorkoutCount,
       ];
 
   FriendshipEntity copyWith({
@@ -30,12 +47,22 @@ class FriendshipEntity extends Equatable {
     String? userId,
     String? friendId,
     DateTime? createdAt,
+    String? friendName,
+    String? friendEmail,
+    String? friendPhotoUrl,
+    int? friendTotalScore,
+    int? friendWorkoutCount,
   }) {
     return FriendshipEntity(
       id: id ?? this.id,
       userId: userId ?? this.userId,
       friendId: friendId ?? this.friendId,
       createdAt: createdAt ?? this.createdAt,
+      friendName: friendName ?? this.friendName,
+      friendEmail: friendEmail ?? this.friendEmail,
+      friendPhotoUrl: friendPhotoUrl ?? this.friendPhotoUrl,
+      friendTotalScore: friendTotalScore ?? this.friendTotalScore,
+      friendWorkoutCount: friendWorkoutCount ?? this.friendWorkoutCount,
     );
   }
 }

--- a/lib/features/social/domain/usecases/remove_friend.dart
+++ b/lib/features/social/domain/usecases/remove_friend.dart
@@ -1,0 +1,19 @@
+import 'package:dartz/dartz.dart';
+import 'package:co_workfit/core/errors/failure.dart';
+import 'package:co_workfit/features/social/domain/repositories/social_repository.dart';
+
+class RemoveFriend {
+  final SocialRepository repository;
+
+  RemoveFriend(this.repository);
+
+  Future<Either<Failure, void>> call({
+    required String userId,
+    required String friendId,
+  }) async {
+    return await repository.removeFriend(
+      userId: userId,
+      friendId: friendId,
+    );
+  }
+}

--- a/lib/features/social/presentation/bloc/social_bloc.dart
+++ b/lib/features/social/presentation/bloc/social_bloc.dart
@@ -2,6 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:co_workfit/features/social/presentation/bloc/social_event.dart';
 import 'package:co_workfit/features/social/presentation/bloc/social_state.dart';
+import 'package:co_workfit/features/social/domain/entities/friendship_entity.dart';
 import 'package:co_workfit/features/social/domain/usecases/get_friends.dart';
 import 'package:co_workfit/features/social/domain/usecases/get_friends_data.dart';
 import 'package:co_workfit/features/social/domain/usecases/send_friend_request.dart';
@@ -9,6 +10,7 @@ import 'package:co_workfit/features/social/domain/usecases/get_received_friend_r
 import 'package:co_workfit/features/social/domain/usecases/accept_friend_request.dart';
 import 'package:co_workfit/features/social/domain/usecases/reject_friend_request.dart';
 import 'package:co_workfit/features/social/domain/usecases/search_users_by_nickname.dart';
+import 'package:co_workfit/features/social/domain/usecases/remove_friend.dart';
 
 class SocialBloc extends Bloc<SocialEvent, SocialState> {
   final GetFriends getFriends;
@@ -18,6 +20,7 @@ class SocialBloc extends Bloc<SocialEvent, SocialState> {
   final AcceptFriendRequest acceptFriendRequest;
   final RejectFriendRequest rejectFriendRequest;
   final SearchUsersByNickname searchUsersByNickname;
+  final RemoveFriend removeFriend;
 
   SocialBloc({
     required this.getFriends,
@@ -27,6 +30,7 @@ class SocialBloc extends Bloc<SocialEvent, SocialState> {
     required this.acceptFriendRequest,
     required this.rejectFriendRequest,
     required this.searchUsersByNickname,
+    required this.removeFriend,
   }) : super(const SocialInitial()) {
     on<LoadFriendsData>(_onLoadFriendsData);
     on<LoadFriends>(_onLoadFriends);
@@ -42,6 +46,7 @@ class SocialBloc extends Bloc<SocialEvent, SocialState> {
           .switchMap(mapper),
     );
     on<ClearSearchResults>(_onClearSearchResults);
+    on<RemoveFriendEvent>(_onRemoveFriend);
   }
 
   Future<void> _onLoadFriendsData(
@@ -181,12 +186,36 @@ class SocialBloc extends Bloc<SocialEvent, SocialState> {
       },
       (_) {
         if (currentState is SocialLoaded) {
+          // 수락된 요청 찾기
+          final acceptedRequest = currentState.receivedRequests
+              .where((req) => req.id == event.requestId)
+              .firstOrNull;
+
+          // 요청 목록에서 제거
           final updatedRequests = currentState.receivedRequests
               .where((req) => req.id != event.requestId)
               .toList();
 
+          // 새 친구를 목록에 추가 (요청자 정보 사용)
+          final updatedFriends = [...currentState.friends];
+          if (acceptedRequest != null) {
+            final newFriend = FriendshipEntity(
+              id: '', // Firestore에서 자동 생성된 ID는 알 수 없음
+              userId: acceptedRequest.receiverId,
+              friendId: acceptedRequest.senderId,
+              createdAt: DateTime.now(),
+              friendName: acceptedRequest.senderName,
+              friendEmail: acceptedRequest.senderEmail,
+              friendPhotoUrl: acceptedRequest.senderPhotoUrl,
+              friendTotalScore: 0, // 초기값, 새로고침 시 업데이트됨
+              friendWorkoutCount: 0,
+            );
+            updatedFriends.insert(0, newFriend); // 맨 앞에 추가
+          }
+
           emit(SocialActionSuccess(
             newState: currentState.copyWith(
+              friends: updatedFriends,
               receivedRequests: updatedRequests,
               requestCount: updatedRequests.length,
             ),
@@ -284,5 +313,49 @@ class SocialBloc extends Bloc<SocialEvent, SocialState> {
     if (currentState is SocialLoaded) {
       emit(currentState.copyWith(searchResults: []));
     }
+  }
+
+  Future<void> _onRemoveFriend(
+    RemoveFriendEvent event,
+    Emitter<SocialState> emit,
+  ) async {
+    final currentState = state;
+
+    if (currentState is SocialLoaded) {
+      emit(SocialActionInProgress(
+        currentState: currentState,
+        actionType: 'remove_friend',
+      ));
+    }
+
+    final result = await removeFriend(
+      userId: event.userId,
+      friendId: event.friendId,
+    );
+
+    result.fold(
+      (failure) {
+        if (currentState is SocialLoaded) {
+          emit(SocialError(failure.message, previousState: currentState));
+        } else {
+          emit(SocialError(failure.message));
+        }
+      },
+      (_) {
+        if (currentState is SocialLoaded) {
+          // 친구 목록에서 삭제된 친구 제거
+          final updatedFriends = currentState.friends
+              .where((f) => f.friendId != event.friendId)
+              .toList();
+
+          emit(SocialActionSuccess(
+            newState: currentState.copyWith(friends: updatedFriends),
+            message: '친구가 삭제되었습니다',
+          ));
+        } else {
+          emit(const SocialLoaded());
+        }
+      },
+    );
   }
 }

--- a/lib/features/social/presentation/bloc/social_event.dart
+++ b/lib/features/social/presentation/bloc/social_event.dart
@@ -90,3 +90,17 @@ class SearchUsersByNicknameEvent extends SocialEvent {
 class ClearSearchResults extends SocialEvent {
   const ClearSearchResults();
 }
+
+// Friend Management Events
+class RemoveFriendEvent extends SocialEvent {
+  final String userId;
+  final String friendId;
+
+  const RemoveFriendEvent({
+    required this.userId,
+    required this.friendId,
+  });
+
+  @override
+  List<Object?> get props => [userId, friendId];
+}

--- a/lib/features/social/presentation/pages/friend_detail_page.dart
+++ b/lib/features/social/presentation/pages/friend_detail_page.dart
@@ -1,18 +1,24 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:co_workfit/core/presentation/base_page.dart';
 import 'package:co_workfit/core/presentation/widgets/standard_app_bar.dart';
 import 'package:co_workfit/core/constants/app_constants.dart';
 import 'package:co_workfit/core/utils/logger.dart';
+import 'package:co_workfit/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:co_workfit/features/auth/presentation/bloc/auth_state.dart';
+import 'package:co_workfit/features/social/domain/entities/friendship_entity.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_bloc.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_event.dart';
+import 'package:co_workfit/features/social/presentation/bloc/social_state.dart';
+import 'package:intl/intl.dart';
 
-/// 친구 상세 페이지 (고스트런 진입점)
+/// 친구 상세 페이지
 class FriendDetailPage extends BasePage {
-  final String friendId;
-  final String friendName;
+  final FriendshipEntity friend;
 
   const FriendDetailPage({
     super.key,
-    required this.friendId,
-    required this.friendName,
+    required this.friend,
   });
 
   @override
@@ -20,58 +26,129 @@ class FriendDetailPage extends BasePage {
 }
 
 class _FriendDetailPageState extends BasePageState<FriendDetailPage> {
-  // TODO: Phase 5에서 실제 친구 데이터로 대체
-  final List<Map<String, dynamic>> _recentRuns = [];
-
   @override
   void loadInitialData() {
-    AppLogger.info('FriendDetailPage', 'Loading friend detail: ${widget.friendId}');
-    // TODO: Phase 5에서 BLoC 이벤트 발생
-    // context.read<FriendBloc>().add(LoadFriendDetail(widget.friendId));
-    // context.read<GhostRunBloc>().add(LoadFriendRecentRuns(widget.friendId));
+    AppLogger.info('FriendDetailPage', 'Loading friend detail: ${widget.friend.friendId}');
   }
 
-  void _startGhostRun() {
-    AppLogger.info('FriendDetailPage', 'Start ghost run with friend: ${widget.friendId}');
-    // TODO: Phase 5에서 고스트 선택 페이지로 이동
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Text('고스트런 기능은 Phase 5에서 구현됩니다'),
-        backgroundColor: Colors.blue,
-      ),
-    );
-  }
-
-  @override
-  PreferredSizeWidget buildAppBar(BuildContext context) {
-    return StandardAppBar(
-      title: widget.friendName,
-    );
-  }
-
-  @override
-  Widget buildBody(BuildContext context) {
-    return SingleChildScrollView(
-      padding: EdgeInsets.all(AppConstants.defaultPadding),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // 친구 프로필 카드
-          _buildProfileCard(),
-          const SizedBox(height: 24),
-
-          // 고스트런 버튼 (가장 눈에 띄게)
-          _buildGhostRunButton(),
-          const SizedBox(height: 24),
-
-          // 최근 운동 기록
-          _buildRecentRunsSection(),
+  void _showDeleteConfirmDialog() {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('친구 삭제'),
+        content: Text('${widget.friend.friendName ?? '이 친구'}님을 친구 목록에서 삭제하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(dialogContext);
+              _removeFriend();
+            },
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: const Text('삭제'),
+          ),
         ],
       ),
     );
   }
 
+  void _removeFriend() {
+    final authState = context.read<AuthBloc>().state;
+    if (authState is Authenticated) {
+      AppLogger.info('FriendDetailPage', 'Remove friend: ${widget.friend.friendId}');
+      context.read<SocialBloc>().add(RemoveFriendEvent(
+            userId: authState.user.id,
+            friendId: widget.friend.friendId,
+          ));
+    }
+  }
+
+  String _formatDate(DateTime date) {
+    return DateFormat('yyyy년 M월 d일').format(date);
+  }
+
+  int _getDaysSinceFriend() {
+    return DateTime.now().difference(widget.friend.createdAt).inDays;
+  }
+
+  @override
+  PreferredSizeWidget buildAppBar(BuildContext context) {
+    return StandardAppBar(
+      title: widget.friend.friendName ?? '친구 상세',
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.delete_outline),
+          tooltip: '친구 삭제',
+          onPressed: _showDeleteConfirmDialog,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget buildBody(BuildContext context) {
+    return BlocListener<SocialBloc, SocialState>(
+      listener: (context, state) {
+        if (state is SocialActionSuccess && state.message == '친구가 삭제되었습니다') {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: Colors.green,
+            ),
+          );
+          Navigator.pop(context); // 삭제 후 이전 페이지로 돌아가기
+        } else if (state is SocialError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      },
+      child: BlocBuilder<SocialBloc, SocialState>(
+        builder: (context, state) {
+          final isLoading = state is SocialActionInProgress &&
+              state.actionType == 'remove_friend';
+
+          return Stack(
+            children: [
+              SingleChildScrollView(
+                padding: EdgeInsets.all(AppConstants.defaultPadding),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildProfileCard(),
+                    const SizedBox(height: 24),
+                    _buildStatsSection(),
+                    const SizedBox(height: 24),
+                    _buildFriendshipInfoSection(),
+                    const SizedBox(height: 24),
+                    _buildDeleteButton(),
+                  ],
+                ),
+              ),
+              if (isLoading)
+                Container(
+                  color: Colors.black26,
+                  child: const Center(
+                    child: CircularProgressIndicator(),
+                  ),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
   Widget _buildProfileCard() {
+    final friendName = widget.friend.friendName ?? '알 수 없음';
+    final friendEmail = widget.friend.friendEmail ?? '';
+
     return Card(
       child: Padding(
         padding: EdgeInsets.all(AppConstants.defaultPadding),
@@ -79,13 +156,21 @@ class _FriendDetailPageState extends BasePageState<FriendDetailPage> {
           children: [
             // 프로필 아바타
             CircleAvatar(
-              radius: 40,
+              radius: 48,
+              backgroundImage: widget.friend.friendPhotoUrl != null
+                  ? NetworkImage(widget.friend.friendPhotoUrl!)
+                  : null,
               backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-              child: Icon(
-                Icons.person,
-                size: 40,
-                color: Theme.of(context).colorScheme.primary,
-              ),
+              child: widget.friend.friendPhotoUrl == null
+                  ? Text(
+                      friendName.isNotEmpty ? friendName[0].toUpperCase() : '?',
+                      style: TextStyle(
+                        fontSize: 32,
+                        fontWeight: FontWeight.bold,
+                        color: Theme.of(context).colorScheme.primary,
+                      ),
+                    )
+                  : null,
             ),
             const SizedBox(width: 16),
 
@@ -95,27 +180,20 @@ class _FriendDetailPageState extends BasePageState<FriendDetailPage> {
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Text(
-                    widget.friendName,
+                    friendName,
                     style: Theme.of(context).textTheme.titleLarge?.copyWith(
                           fontWeight: FontWeight.bold,
                         ),
                   ),
-                  const SizedBox(height: 4),
-                  Text(
-                    '함께 달린 지 30일',
-                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          color: Colors.grey[600],
-                        ),
-                  ),
-                  const SizedBox(height: 8),
-                  // 통계 요약
-                  Row(
-                    children: [
-                      _buildStatChip(Icons.directions_run, '127회'),
-                      const SizedBox(width: 8),
-                      _buildStatChip(Icons.social_distance, '523km'),
-                    ],
-                  ),
+                  if (friendEmail.isNotEmpty) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      friendEmail,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Colors.grey[600],
+                          ),
+                    ),
+                  ],
                 ],
               ),
             ),
@@ -125,94 +203,157 @@ class _FriendDetailPageState extends BasePageState<FriendDetailPage> {
     );
   }
 
-  Widget _buildStatChip(IconData icon, String label) {
-    return Chip(
-      avatar: Icon(icon, size: 16),
-      label: Text(label, style: const TextStyle(fontSize: 12)),
-      visualDensity: VisualDensity.compact,
-    );
-  }
+  Widget _buildStatsSection() {
+    final totalScore = widget.friend.friendTotalScore ?? 0;
+    final workoutCount = widget.friend.friendWorkoutCount ?? 0;
 
-  Widget _buildGhostRunButton() {
-    return SizedBox(
-      width: double.infinity,
-      child: ElevatedButton.icon(
-        onPressed: _startGhostRun,
-        icon: const Icon(Icons.directions_run, size: 28),
-        label: const Text(
-          '이 친구의 고스트로 달리기',
-          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        ),
-        style: ElevatedButton.styleFrom(
-          padding: EdgeInsets.all(AppConstants.defaultPadding),
-          backgroundColor: Theme.of(context).colorScheme.primary,
-          foregroundColor: Theme.of(context).colorScheme.onPrimary,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildRecentRunsSection() {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          '최근 러닝 기록',
+          '운동 통계',
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
         ),
         const SizedBox(height: 12),
-
-        // TODO: Phase 5에서 실제 데이터로 대체
-        _recentRuns.isEmpty
-            ? Card(
-                child: Padding(
-                  padding: EdgeInsets.all(AppConstants.defaultPadding * 2),
-                  child: Center(
-                    child: Column(
-                      children: [
-                        Icon(
-                          Icons.directions_run_outlined,
-                          size: 48,
-                          color: Colors.grey[400],
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          '최근 러닝 기록이 없습니다',
-                          style: TextStyle(color: Colors.grey[600]),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              )
-            : ListView.builder(
-                shrinkWrap: true,
-                physics: const NeverScrollableScrollPhysics(),
-                itemCount: _recentRuns.length,
-                itemBuilder: (context, index) {
-                  return Card(
-                    margin: const EdgeInsets.only(bottom: 8),
-                    child: ListTile(
-                      leading: const Icon(Icons.directions_run),
-                      title: Text('러닝 ${index + 1}'),
-                      subtitle: const Text('5.2km • 28분 • 5:23/km'),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.play_arrow),
-                        onPressed: () {
-                          AppLogger.info('FriendDetailPage', 'Ghost run selected: ${index + 1}');
-                          _startGhostRun();
-                        },
-                      ),
-                    ),
-                  );
-                },
+        Row(
+          children: [
+            Expanded(
+              child: _buildStatCard(
+                icon: Icons.emoji_events,
+                label: '총 점수',
+                value: totalScore.toString(),
+                color: Colors.amber,
               ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: _buildStatCard(
+                icon: Icons.directions_run,
+                label: '운동 횟수',
+                value: '$workoutCount회',
+                color: Colors.blue,
+              ),
+            ),
+          ],
+        ),
       ],
+    );
+  }
+
+  Widget _buildStatCard({
+    required IconData icon,
+    required String label,
+    required String value,
+    required Color color,
+  }) {
+    return Card(
+      child: Padding(
+        padding: EdgeInsets.all(AppConstants.defaultPadding),
+        child: Column(
+          children: [
+            Icon(icon, size: 32, color: color),
+            const SizedBox(height: 8),
+            Text(
+              value,
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              label,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Colors.grey[600],
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFriendshipInfoSection() {
+    final daysSinceFriend = _getDaysSinceFriend();
+    final friendSince = _formatDate(widget.friend.createdAt);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '친구 정보',
+          style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+        ),
+        const SizedBox(height: 12),
+        Card(
+          child: Padding(
+            padding: EdgeInsets.all(AppConstants.defaultPadding),
+            child: Column(
+              children: [
+                _buildInfoRow(
+                  icon: Icons.calendar_today,
+                  label: '친구가 된 날',
+                  value: friendSince,
+                ),
+                const Divider(),
+                _buildInfoRow(
+                  icon: Icons.schedule,
+                  label: '함께한 기간',
+                  value: daysSinceFriend == 0 ? '오늘' : '$daysSinceFriend일',
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildInfoRow({
+    required IconData icon,
+    required String label,
+    required String value,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        children: [
+          Icon(icon, size: 20, color: Colors.grey[600]),
+          const SizedBox(width: 12),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Colors.grey[600],
+                ),
+          ),
+          const Spacer(),
+          Text(
+            value,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDeleteButton() {
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: _showDeleteConfirmDialog,
+        icon: const Icon(Icons.person_remove, color: Colors.red),
+        label: const Text('친구 삭제'),
+        style: OutlinedButton.styleFrom(
+          foregroundColor: Colors.red,
+          side: const BorderSide(color: Colors.red),
+          padding: EdgeInsets.all(AppConstants.defaultPadding),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/social/presentation/pages/received_requests_page.dart
+++ b/lib/features/social/presentation/pages/received_requests_page.dart
@@ -58,6 +58,7 @@ class _ReceivedRequestsPageState extends BasePageState<ReceivedRequestsPage> {
           itemCount: requests.length,
           itemBuilder: (context, index) {
             final request = requests[index];
+            final senderName = request.senderName ?? '알 수 없음';
             return Card(
               margin: const EdgeInsets.symmetric(
                 horizontal: AppConstants.defaultPadding,
@@ -69,10 +70,10 @@ class _ReceivedRequestsPageState extends BasePageState<ReceivedRequestsPage> {
                       ? NetworkImage(request.senderPhotoUrl!)
                       : null,
                   child: request.senderPhotoUrl == null
-                      ? Text(request.senderName[0].toUpperCase())
+                      ? Text(senderName.isNotEmpty ? senderName[0].toUpperCase() : '?')
                       : null,
                 ),
-                title: Text(request.senderName),
+                title: Text(senderName),
                 subtitle: Text(
                   '${_formatDate(request.createdAt)}에 요청',
                   style: const TextStyle(fontSize: 12),

--- a/lib/features/social/presentation/widgets/friends_list_tab.dart
+++ b/lib/features/social/presentation/widgets/friends_list_tab.dart
@@ -117,6 +117,10 @@ class FriendsListTab extends StatelessWidget {
               // 친구 목록 셀
               final friendIndex = requestCount > 0 ? index - 1 : index;
               final friend = friends[friendIndex];
+              final friendName = friend.friendName ?? '알 수 없음';
+              final friendEmail = friend.friendEmail ?? '';
+              final friendTotalScore = friend.friendTotalScore ?? 0;
+              final friendWorkoutCount = friend.friendWorkoutCount ?? 0;
               return Card(
                 margin: const EdgeInsets.symmetric(
                   horizontal: AppConstants.defaultPadding,
@@ -128,17 +132,17 @@ class FriendsListTab extends StatelessWidget {
                         ? NetworkImage(friend.friendPhotoUrl!)
                         : null,
                     child: friend.friendPhotoUrl == null
-                        ? Text(friend.friendName[0].toUpperCase())
+                        ? Text(friendName.isNotEmpty ? friendName[0].toUpperCase() : '?')
                         : null,
                   ),
-                  title: Text(friend.friendName),
+                  title: Text(friendName),
                   subtitle: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(friend.friendEmail),
+                      if (friendEmail.isNotEmpty) Text(friendEmail),
                       const SizedBox(height: 4),
                       Text(
-                        '점수: ${friend.friendTotalScore} | 운동: ${friend.friendWorkoutCount}회',
+                        '점수: $friendTotalScore | 운동: $friendWorkoutCount회',
                         style: TextStyle(
                           fontSize: 12,
                           color: Colors.grey[600],
@@ -152,8 +156,7 @@ class FriendsListTab extends StatelessWidget {
                       context,
                       MaterialPageRoute(
                         builder: (context) => FriendDetailPage(
-                          friendId: friend.friendId,
-                          friendName: friend.friendName,
+                          friend: friend,
                         ),
                       ),
                     );


### PR DESCRIPTION
## Summary
- 친구 상세 페이지 실제 데이터 연동 (프로필, 운동 통계, 친구 정보 표시)
- 친구 삭제 기능 추가 (RemoveFriend UseCase, BLoC 이벤트)
- 친구 요청 수락 시 즉시 친구 목록에 반영되도록 개선
- Entity에 사용자 정보 필드 추가 (Firestore JOIN 쿼리로 조회)
- Firestore 복합 인덱스 설정 파일 추가

## Changes
### Domain Layer
- `RemoveFriend` UseCase 생성

### Data Layer  
- `FriendRequestEntity`, `FriendshipEntity`에 사용자 정보 필드 추가
- `FriendRequestModel.fromFirestoreWithSender` 팩토리 추가
- DataSource에서 사용자 정보 JOIN 쿼리 구현 (10개씩 배치 처리)

### Presentation Layer
- `SocialBloc`에 `RemoveFriendEvent` 핸들러 추가
- `FriendDetailPage` 전면 개편 (FriendshipEntity 기반)

### Infrastructure
- `firestore.indexes.json` 추가 (복합 인덱스 정의)
- `firebase.json`에 Firestore 인덱스 설정 연결

## Test plan
- [ ] 친구 목록에서 친구 클릭 시 상세 페이지 표시 확인
- [ ] 친구 상세 페이지에서 프로필, 통계, 친구 정보 표시 확인
- [ ] 친구 삭제 버튼 클릭 → 확인 다이얼로그 → 삭제 → 목록 복귀 확인
- [ ] 친구 요청 수락 시 친구 목록에 즉시 추가되는지 확인
- [ ] flutter analyze 통과 (0 errors)

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)